### PR TITLE
Don't include env vars in CI output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,4 +38,4 @@ jobs:
             ENVIRONMENT="production" ||
             ENVIRONMENT="staging"
           echo "env is $ENVIRONMENT"
-          inv $ENVIRONMENT image deploy
+          inv $ENVIRONMENT image deploy --verbosity=0

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -1,4 +1,4 @@
 ---
 - src: https://github.com/caktus/ansible-role-django-k8s
   name: caktus.django-k8s
-  version: v0.0.9
+  version: v0.0.11

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -8,7 +8,7 @@ ipython
 jupyterlab
 
 # deploy
--e git+https://github.com/caktus/invoke-kubesae@0.0.10#egg=invoke-kubesae
+-e git+https://github.com/caktus/invoke-kubesae@0.0.11#egg=invoke-kubesae
 troposphere
 
 # AWS tools


### PR DESCRIPTION
This takes advantages of new releases of django-k8s and invoke-kubesae which allow us to do deploys without leaking environment variables into the log output.