### PR TITLE
HP-33-try-3 get back button working

### DIFF
--- a/apps/hip/models.py
+++ b/apps/hip/models.py
@@ -1,3 +1,5 @@
+from django.urls import reverse
+
 from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField
@@ -82,3 +84,11 @@ class StaticPage(Page):
     promote_panels = [
         FieldPanel("slug"),
     ]
+
+    def get_context(self, request):
+        """
+        Add the HTTP_REFERER to the context so that we can show a back button.
+        """
+        context = super().get_context(request)
+        context["prev_url"] = request.META.get("HTTP_REFERER", reverse("home"))
+        return context

--- a/apps/hip/templates/hip/static_page.html
+++ b/apps/hip/templates/hip/static_page.html
@@ -16,7 +16,7 @@
     <div class="columns">
       <div class="column">
 	<div class="pt-5 px-5">
-	  <a href="javascript:history.back()">< Back</a>
+	  <a href="{{ prev_url }}">< Back</a>
 	</div>
 
         {% for block in page.body %}

--- a/apps/hip/tests.py
+++ b/apps/hip/tests.py
@@ -1,3 +1,0 @@
-# Create your tests here.
-def test_answer():
-    assert 1 == 1

--- a/apps/hip/tests/test_models.py
+++ b/apps/hip/tests/test_models.py
@@ -1,0 +1,24 @@
+from django.urls import reverse
+
+from apps.hip.models import StaticPage
+
+
+def test_static_page_sets_prev_to_referer(db, rf):
+    sp = StaticPage()
+    # make a fake request and set HTTP_REFERER
+    request = rf.get("/foo")
+    referring_url = "https://example.com"
+    request.META["HTTP_REFERER"] = referring_url
+
+    context = sp.get_context(request)
+    assert context["prev_url"] == referring_url
+
+
+def test_static_page_prev_defaults_to_home(db, rf):
+    s = StaticPage()
+    # make a fake request and leave HTTP_REFERER unset
+    request = rf.get("/foo")
+    assert request.META.get("HTTP_REFERER") is None
+
+    context = s.get_context(request)
+    assert context["prev_url"] == reverse("home")


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-33

Using `javascript:history.back()` doesn't work if the user has clicked on right-nav links within the page. This instead uses the `HTTP_REFERER` header to get the actual last page that the user was on, defaulting to the home page URL if it is not present (like if the user came from an email link or something)