### PR TITLE
Fix JS

### DIFF
--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,0 +1,28 @@
+version: '3.4'
+# This file is used for the `inv image.up` command which can be used to test a deployed
+# image locally
+services:
+  app:
+    environment:
+      DJANGO_SETTINGS_MODULE: hip.settings.deploy
+      DATABASE_URL: postgres://postgres@db:5432/hip
+      CACHE_HOST: cache:11211
+      ENVIRONMENT: local
+      DJANGO_SECRET_KEY: insecure-dev-key
+      DOMAIN: localhost
+      EMAIL_HOST: mailhog
+      EMAIL_PORT: 1025
+      SESSION_COOKIE_SECURE: "False"
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      target: deploy
+    command: ["uwsgi", "--show-config"]
+    links:
+      - db:db
+    ports:
+      - "8000:8000"
+  cache:
+    image: memcached:1.6-alpine
+  mailhog:
+    image: mailhog/mailhog:v1.0.0

--- a/hip/templates/base.html
+++ b/hip/templates/base.html
@@ -26,9 +26,6 @@
       </script>
     {% endif %}
 
-    {# Global javascript #}
-    {% render_bundle 'main' %}
-
     {# favicon #}
     <link rel="shortcut icon" href="{% static 'favicon.ico' %}" type="image/x-icon">
 
@@ -43,16 +40,18 @@
     {% wagtailuserbar 'bottom-left' %}
     {% include 'includes/header.html' %}
     <div class="columns is-desktop">
-        {% block sidebar %}
-          {% include 'includes/sidebar.html' with hidden_desktop=False %}
-        {% endblock %}
-        <div class="column">
-            {% block content %}{% endblock %}
-        </div>
+      {% block sidebar %}
+        {% include 'includes/sidebar.html' with hidden_desktop=False %}
+      {% endblock %}
+      <div class="column">
+        {% block content %}{% endblock %}
+      </div>
     </div>
     {% include 'includes/footer.html' %}
 
+    {# Global javascript #}
+    {% render_bundle 'main' %}
+
     {% block extra_js %}{% endblock %}
-    <script src="{% static 'js/bundles/main.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
2 things in this PR:
1. Bring back the docker-compose-deploy.yml file that allows you to do `inv image.up` to test an image locally
2. Delete the extra bundle that we were including in the template (and move the correct bundle down to the end of the DOM so it doesn't block page load)

I'm not 100% sure that this was the reason that JS was not working on staging, but I deployed this image and it looks like staging is working now