### PR TITLE
[HP-49] Show Datetimes US Eastern Time Zone

### DIFF
--- a/hip/settings/base.py
+++ b/hip/settings/base.py
@@ -150,7 +150,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "America/New_York"
 
 USE_I18N = True
 


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-49

This pull request sets the project `TIME_ZONE` to 'America/New_York', so all dates and datetimes dislpay in that timezone, including in the 'Recently Updated' table.