### PR TITLE
HP-44-vinod Wrap quicklink cards at 4 per row

### DIFF
--- a/apps/hip/templates/hip/home_page.html
+++ b/apps/hip/templates/hip/home_page.html
@@ -7,9 +7,9 @@
 
 {% block content %}
   <div class="homepage-padding-hip">
-    <section class="columns">
+    <section class="columns is-multiline">
       {% for quick_link in page.quick_links %}
-        <div class="column is-relative has-text-centered quicklink-padding-hip">
+        <div class="column is-relative is-one-quarter has-text-centered quicklink-padding-hip">
           <div class="arrow-right-hip ml-4 mt-4"></div>
           <div class="p-4 is-fullheight-hip quicklink-color-hip">
             <a href="{{ quick_link.value.link }}">

--- a/hip/static/styles/_colors.scss
+++ b/hip/static/styles/_colors.scss
@@ -7,5 +7,6 @@ $light-grey: #F0F0F0;
 
 $dark-blue: #0F4D90;
 $light-blue: #25CEF7;
+$quicklink-blue: #DAEDFE;
 
 $white: #FFFFFF;

--- a/hip/static/styles/pages/home_page.scss
+++ b/hip/static/styles/pages/home_page.scss
@@ -11,7 +11,7 @@
 }
 
 .quicklink-color-hip {
-  background-color: $light-blue;
+  background-color: $quicklink-blue;
 }
 
 .arrow-right-hip {


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-44

Replacement for #29 

This uses Bulma's helpers to make the cards wrap at 4 cards per row, and changes the background color to match what is in the wireframe now.