### PR TITLE
Make modal's min-height be 100 percent of the viewport height, instea…

### DIFF
--- a/hip/static/styles/_mixins.scss
+++ b/hip/static/styles/_mixins.scss
@@ -71,7 +71,7 @@
   bottom: 0;
   right: 0;
   width: 100%;
-  min-height: 100%;
+  min-height: 100vh;
   max-height: auto;
   z-index: 1000;
 }


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-51

This issue seems to only be reproducible on an actual mobile device. This can be accomplished by navigating to the hip site on your mobile phone.

My thinking is that modal needs to have a minimum height of 100 percent of the viewport's height. Originally this value was set to 100% of its parent container's height. I'm wondering if using `100vh` is more accurate. 