### PR TITLE
Update fonts to match wireframes

### DIFF
--- a/apps/hip/templates/includes/header.html
+++ b/apps/hip/templates/includes/header.html
@@ -47,7 +47,7 @@
               <i class="bullhorn-icon-hip"></i>
             </span>
             <span class="button is-size-7-touch header-btn-hip ml-0">
-              <strong>Report Disease</strong>
+              <strong>Report a Disease</strong>
             </span>
           </a>
         </div>

--- a/hip/static/styles/common.scss
+++ b/hip/static/styles/common.scss
@@ -31,6 +31,11 @@
 
 // ---------------- Button/Links----------- //
 
+.button {
+  font-family: 'Montserrat', sans-serif;
+  text-transform: uppercase;
+}
+
 .btn-no-border-hip {
   border: none;
 }

--- a/hip/static/styles/includes/header.scss
+++ b/hip/static/styles/includes/header.scss
@@ -45,6 +45,8 @@
 .header-btn-hip {
   @include light-blue-bg;
   border-radius: 0;
+  text-transform: uppercase;
+  font-family: 'Montserrat', sans-serif;
 }
 
 .header-icon-hip {

--- a/hip/static/styles/includes/header.scss
+++ b/hip/static/styles/includes/header.scss
@@ -45,8 +45,6 @@
 .header-btn-hip {
   @include light-blue-bg;
   border-radius: 0;
-  text-transform: uppercase;
-  font-family: 'Montserrat', sans-serif;
 }
 
 .header-icon-hip {

--- a/hip/static/styles/pages/base.scss
+++ b/hip/static/styles/pages/base.scss
@@ -1,6 +1,10 @@
 @import "../colors";
 @import "../mixins";
 
+body {
+  font-family: 'Open Sans', sans-serif;
+}
+
 .is-fixed {
   position: fixed;
 }

--- a/hip/templates/base.html
+++ b/hip/templates/base.html
@@ -32,6 +32,11 @@
     {# sass Stylesheets #}
     <link href="{% sass_src 'styles/bundle.scss' %}" rel="stylesheet" type="text/css" />
 
+    {# OpenSans font for text, Montserrat for buttons #}
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&display=swap" rel="stylesheet">
+
     {% block extra_css %}
     {% endblock %}
   </head>


### PR DESCRIPTION
This:
1. adds montserrat and open-sans using the [docs from Google](https://fonts.google.com/specimen/Open+Sans?preview.text_type=custom&sidebar.open=true&selection.family=Open+Sans:ital@1).
2. Uses montserrat for buttons and open-sans for all other text
3. Makes text of buttons uppercase