### PR TITLE
[HP-47] Align Snippet With Other Column

### DIFF
--- a/apps/hip/templates/hip/home_page.html
+++ b/apps/hip/templates/hip/home_page.html
@@ -21,7 +21,7 @@
       {% endfor %}
     </section>
 
-    <section class="columns is-vcentered is-desktop">
+    <section class="columns is-desktop">
       <div class="column is-6-desktop">
         <h3 class="is-size-4 pl-4"><strong>Report A Disease</strong></h3>
         {% contact_info %}

--- a/apps/hip/templates/hip/home_page.html
+++ b/apps/hip/templates/hip/home_page.html
@@ -21,7 +21,7 @@
       {% endfor %}
     </section>
 
-    <section class="columns is-desktop">
+    <section class="columns is-desktop is-full-height-hip">
       <div class="column is-6-desktop">
         <h3 class="is-size-4 pl-4"><strong>Report A Disease</strong></h3>
         {% contact_info %}

--- a/apps/hip/templates/tags/contact_info.html
+++ b/apps/hip/templates/tags/contact_info.html
@@ -16,7 +16,7 @@
         </div>
       </div>
     </div>
-    <div class="columns is-vcentered is-mobile py-2 px-4 contact-container-hip">
+    <div class="columns is-vcentered is-mobile pt-2 px-4 contact-container-hip">
       <div class="column is-3 is-mobile dark-blue-bg-hip has-text-centered mr-1 is-full-height-hip">
         <span class="is-block moon-icon-hip is-size-3 pt-4"></span>
         <h6 class=" column is-size-6">After Hours</h6>


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-47

This pull request removes the `is-vcentered` CSS class from the parent `<div>` of both the snippet column and the 'About HIP' column, so the two columns align with each other vertically.