### PR TITLE
HP-64: Health alerts legend, filter widget and design tweaks

### DIFF
--- a/apps/health_alerts/static/js/healthAlertPriorityFilter.js
+++ b/apps/health_alerts/static/js/healthAlertPriorityFilter.js
@@ -8,8 +8,8 @@ export default function() {
       const allRows = document.querySelectorAll("[data-priority]");
       // we want to show any row that has the selectedPriority
       let rowsToShow = document.querySelectorAll(`[data-priority~="${selectedPriority}"]`);
-      if (selectedPriority === '0') {
-        // user chose '0', we will show all rows again
+      if (selectedPriority === 'All') {
+        // show all rows again
         rowsToShow = allRows;
       }
       // filter the rows, restripe them, and then filter the right side links

--- a/apps/health_alerts/static/js/healthAlertPriorityFilter.js
+++ b/apps/health_alerts/static/js/healthAlertPriorityFilter.js
@@ -1,0 +1,64 @@
+export default function() {
+  const selectElement = document.querySelector('.select-priority');
+
+  if (selectElement) {
+    // add a handler for the change event for the priority select dropdown
+    selectElement.addEventListener('change', (event) => {
+      const selectedPriority = event.target.value;
+      const allRows = document.querySelectorAll("[data-priority]");
+      // we want to show any row that has the selectedPriority
+      let rowsToShow = document.querySelectorAll(`[data-priority~="${selectedPriority}"]`);
+      if (selectedPriority === '0') {
+        // user chose '0', we will show all rows again
+        rowsToShow = allRows;
+      }
+      // filter the rows, restripe them, and then filter the right side links
+      filterRows(rowsToShow, allRows);
+      restripeRows(rowsToShow);
+      filterRightSideLinks(rowsToShow);
+    })
+  }
+
+  function filterRows(rowsToShow, allRows) {
+    // hide all the rows
+    allRows.forEach(row => row.hidden = true);
+    // show just the rows the user wants to see
+    rowsToShow.forEach(row => row.hidden = false);
+  }
+
+  function restripeRows(rows) {
+    const greyClass = "row-bg-grey-hip";
+    const whiteClass = "row-bg-white-hip";
+    let currentClass = whiteClass;
+    let nextClass = greyClass;
+
+    rows.forEach(row => {
+      if (row.dataset.year !== undefined) {
+        // Only the year header row has a `data-year` attribute, so this must be a new
+        // year. Therefore, restart the colors, starting at white
+        currentClass = whiteClass;
+        nextClass = greyClass;
+      } else {
+        // swap the colors
+        [currentClass, nextClass] = [nextClass, currentClass];
+      }
+      row.classList.add(currentClass);
+      row.classList.remove(nextClass);
+    });
+  }
+
+  function filterRightSideLinks(rows){
+    // given the list of active rows, make sure only the right side links referring to
+    // those years are shown
+    const allRightSideLinks = document.querySelectorAll("[data-ref]");
+    // hide all the right side links
+    allRightSideLinks.forEach(row => row.hidden=true);
+    rows.forEach(row => {
+      // find all of the "year" values and unhide those rightsidelinks
+      if (row.dataset.year !== undefined) {
+        let rightSideLink = document.querySelector(`[data-ref=section-${row.dataset.year}]`);
+        rightSideLink.hidden = false;
+      }
+    });
+  }
+};

--- a/apps/health_alerts/static/js/healthAlertPriorityFilter.js
+++ b/apps/health_alerts/static/js/healthAlertPriorityFilter.js
@@ -1,5 +1,6 @@
 export default function() {
   const selectElement = document.querySelector('.select-priority');
+  const alertsMissingEl = document.querySelector(".alerts-missing-hip");
 
   if (selectElement) {
     // add a handler for the change event for the priority select dropdown
@@ -24,6 +25,12 @@ export default function() {
     allRows.forEach(row => row.hidden = true);
     // show just the rows the user wants to see
     rowsToShow.forEach(row => row.hidden = false);
+    if (rowsToShow.length === 0) {
+      // if all rows are hidden, then show our special "no alerts found" row
+      alertsMissingEl.hidden = false;
+    } else {
+      alertsMissingEl.hidden = true;
+    }
   }
 
   function restripeRows(rows) {

--- a/apps/health_alerts/templates/health_alerts/health_alert_index_page.html
+++ b/apps/health_alerts/templates/health_alerts/health_alert_index_page.html
@@ -31,25 +31,22 @@
       </div>
 
       {# Filter widget #}
-      <div class="filter-widget-hip card">
-        <div class="card-content">
-          <div class="content">
-            <form class="columns">
-              <div class="column is-half">
-                <div class="select">
-                  <select>
-                    <option>Filter by priority</option>
-                    <option>Coming Soon!</option>
-                  </select>
-                </div>
-              </div>
-              <div class="column">
-                <span class="is-size-6">Filter by tag:</span>
-                <span class="tag is-size-6">COVID-19</span>
-                <span class="tag is-size-6">Hepatitis A</span>
-              </div>
-            </form>
+      <div class="filter-widget-hip columns m-0">
+        <div class="column is-half">
+          <div class="select">
+            <select class="select-priority">
+              <option value="0">Filter by priority</option>
+              <option value="4">Alert</option>
+              <option value="3">Advisory</option>
+              <option value="2">Notification</option>
+              <option value="1">Update</option>
+            </select>
           </div>
+        </div>
+        <div class="column">
+          <span class="is-size-6">Filter by tag:</span>
+          <span class="tag is-size-6">COVID-19</span>
+          <span class="tag is-size-6">Hepatitis A</span>
         </div>
       </div>
 
@@ -57,7 +54,10 @@
       <table class="table alert-table-hip">
         {% regroup health_alerts by alert_date.year as health_alert_list %}
         {% for year in health_alert_list %}
-          <tr>
+          <tr
+            data-priority="{% for alert in year.list %}{{ alert.priority }} {% endfor %}"
+            data-year="{{ year.grouper }}"
+          >
             <td colspan="3" class="pl-0">
               {# nav-heading-hip is used by right_scroll_nav as link targets #}
               <div class="nav-heading-hip" id="section-{{ year.grouper }}"></div>
@@ -83,7 +83,10 @@
           {% endif %}
 
           {% for alert in year.list %}
-            <tr class="{% if forloop.counter|divisibleby:2 %}row-bg-white-hip{% else %}row-bg-grey-hip{% endif %}">
+            <tr
+              class="{% if forloop.counter|divisibleby:2 %}row-bg-white-hip{% else %}row-bg-grey-hip{% endif %}"
+              data-priority="{{ alert.priority }}"
+            >
               <td class="topic"><a href="{{ alert.specific.alert_file.url }}">{{ alert.title }}</a></td>
               <td class="priority {{ alert.get_priority_display|lower }}-hip">
                 <i class="fa {{ alert.get_priority_icon }}" aria-hidden="true"></i>

--- a/apps/health_alerts/templates/health_alerts/health_alert_index_page.html
+++ b/apps/health_alerts/templates/health_alerts/health_alert_index_page.html
@@ -80,6 +80,11 @@
               </th>
               <th>Date of Alert</th>
             </tr>
+            <tr>
+              <td class="alerts-missing-hip" colspan="3" hidden>
+                No Health Alerts Found
+              </td>
+            </tr>
           {% endif %}
 
           {% for alert in year.list %}

--- a/apps/health_alerts/templates/health_alerts/health_alert_index_page.html
+++ b/apps/health_alerts/templates/health_alerts/health_alert_index_page.html
@@ -6,84 +6,84 @@
     <div class="column p-6">
 
       <div class="level">
-	{# Title is on the left #}
-	<div class="level-left">
-	  <div class="level-item">
-	    <p class="title">
+        {# Title is on the left #}
+        <div class="level-left">
+          <div class="level-item">
+            <p class="title">
               {{ page.title }}
-	    </p>
-	  </div>
-	</div>
+            </p>
+          </div>
+        </div>
 
-	{# Sign up button is on the right #}
-	<div class="level-right">
-	  <div class="level-item">
+        {# Sign up button is on the right #}
+        <div class="level-right">
+          <div class="level-item">
             <a href="/fixme-alert-signup" class="is-block">
               <span class="button is-size-7-touch header-icon-hip">
-		<i class="email-icon-hip"></i>
+                <i class="email-icon-hip"></i>
               </span>
               <span class="button is-size-7-touch header-btn-hip">
-		<strong>Sign Up For Alerts</strong>
+                <strong>Sign Up For Alerts</strong>
               </span>
             </a>
-	  </div>
-	</div>
+          </div>
+        </div>
       </div>
 
       {# Filter widget #}
       <div class="filter-widget-hip card">
-	<div class="card-content">
-	  <div class="content">
-	    <form class="columns">
-	      <div class="column is-half">
-		<div class="select">
-		  <select>
-		    <option>Filter by priority</option>
-		    <option>Coming Soon!</option>
-		  </select>
-		</div>
-	      </div>
-	      <div class="column">
-		<span class="is-size-6">Filter by tag:</span>
-		<span class="tag is-size-6">COVID-19</span>
-		<span class="tag is-size-6">Hepatitis A</span>
-	      </div>
-	    </form>
-	  </div>
-	</div>
+        <div class="card-content">
+          <div class="content">
+            <form class="columns">
+              <div class="column is-half">
+                <div class="select">
+                  <select>
+                    <option>Filter by priority</option>
+                    <option>Coming Soon!</option>
+                  </select>
+                </div>
+              </div>
+              <div class="column">
+                <span class="is-size-6">Filter by tag:</span>
+                <span class="tag is-size-6">COVID-19</span>
+                <span class="tag is-size-6">Hepatitis A</span>
+              </div>
+            </form>
+          </div>
+        </div>
       </div>
 
       {# Main content table of Health Alerts #}
       <table class="table alert-table-hip">
-	{% regroup health_alerts by alert_date.year as health_alert_list %}
-	{% for year in health_alert_list %}
-	  <tr>
-	    <td colspan="3">
-	      {# nav-heading-hip is used by right_scroll_nav as link targets #}
-	      <div class="nav-heading-hip" id="section-{{ year.grouper }}"></div>
+        {% regroup health_alerts by alert_date.year as health_alert_list %}
+        {% for year in health_alert_list %}
+          <tr>
+            <td colspan="3">
+              {# nav-heading-hip is used by right_scroll_nav as link targets #}
+              <div class="nav-heading-hip" id="section-{{ year.grouper }}"></div>
               <div class="is-size-4 pt-5 row-bg-white-hip">{{ year.grouper }}</div>
-	    </td>
-	  </tr>
-	  {# only the first year has the table header #}
-	  {% if forloop.counter == 1 %}
+            </td>
+          </tr>
+          {# only the first year has the table header #}
+          {% if forloop.counter == 1 %}
             <tr>
-	      <th>Topic</th>
-	      <th>Priority</th>
-	      <th>Date of Alert</th>
+              <th>Topic</th>
+              <th>Priority</th>
+              <th>Date of Alert</th>
             </tr>
-	  {% endif %}
+          {% endif %}
 
           {% for alert in year.list %}
             <tr class="{% if forloop.counter|divisibleby:2 %}row-bg-white-hip{% else %}row-bg-grey-hip{% endif %}">
               <td><a href="{{ alert.specific.alert_file.url }}">{{ alert.title }}</a></td>
-	      <td class="is-size-5 {{ alert.get_priority_display|lower }}-hip">
-		<i class="fa {{ alert.get_priority_icon }}" aria-hidden="true"></i>
-		{{ alert.get_priority_display }}
-	      </td>
+              <td class="is-size-5 {{ alert.get_priority_display|lower }}-hip">
+                <i class="fa {{ alert.get_priority_icon }}" aria-hidden="true"></i>
+                {{ alert.get_priority_display }}
+              </td>
               <td>{{ alert.specific.alert_date | date:"M j, Y" }}</td>
             </tr>
           {% endfor %}
-	{% endfor %}
+        {% endfor %}
       </table>
     </div>
 

--- a/apps/health_alerts/templates/health_alerts/health_alert_index_page.html
+++ b/apps/health_alerts/templates/health_alerts/health_alert_index_page.html
@@ -58,29 +58,38 @@
         {% regroup health_alerts by alert_date.year as health_alert_list %}
         {% for year in health_alert_list %}
           <tr>
-            <td colspan="3">
+            <td colspan="3" class="pl-0">
               {# nav-heading-hip is used by right_scroll_nav as link targets #}
               <div class="nav-heading-hip" id="section-{{ year.grouper }}"></div>
-              <div class="is-size-4 pt-5 row-bg-white-hip">{{ year.grouper }}</div>
+              <div class="is-size-4 pt-5 year-hip row-bg-white-hip">{{ year.grouper }}</div>
             </td>
           </tr>
           {# only the first year has the table header #}
           {% if forloop.counter == 1 %}
             <tr>
               <th>Topic</th>
-              <th>Priority</th>
+              <th>
+                <span class="is-mobile desktop-hidden-hip">Priority</span>
+                <div class="dropdown is-hoverable is-desktop mobile-hidden-hip">
+                  <span>Priority</span>
+                  <span class="icon">
+                    <i class="fa fa-info-circle" aria-hidden="true"></i>
+                  </span>
+                  {% include "includes/health_alert_legend.html" %}
+                </div>
+              </th>
               <th>Date of Alert</th>
             </tr>
           {% endif %}
 
           {% for alert in year.list %}
             <tr class="{% if forloop.counter|divisibleby:2 %}row-bg-white-hip{% else %}row-bg-grey-hip{% endif %}">
-              <td><a href="{{ alert.specific.alert_file.url }}">{{ alert.title }}</a></td>
-              <td class="is-size-5 {{ alert.get_priority_display|lower }}-hip">
+              <td class="topic"><a href="{{ alert.specific.alert_file.url }}">{{ alert.title }}</a></td>
+              <td class="priority {{ alert.get_priority_display|lower }}-hip">
                 <i class="fa {{ alert.get_priority_icon }}" aria-hidden="true"></i>
                 {{ alert.get_priority_display }}
               </td>
-              <td>{{ alert.specific.alert_date | date:"M j, Y" }}</td>
+              <td class="alert-date">{{ alert.specific.alert_date | date:"M j, Y" }}</td>
             </tr>
           {% endfor %}
         {% endfor %}

--- a/apps/health_alerts/templates/health_alerts/health_alert_index_page.html
+++ b/apps/health_alerts/templates/health_alerts/health_alert_index_page.html
@@ -35,11 +35,11 @@
         <div class="column is-half">
           <div class="select">
             <select class="select-priority">
-              <option value="0">Filter by priority</option>
-              <option value="4">Alert</option>
-              <option value="3">Advisory</option>
-              <option value="2">Notification</option>
-              <option value="1">Update</option>
+              <option value="All">Filter by priority</option>
+              <option value="Alert">Alert</option>
+              <option value="Advisory">Advisory</option>
+              <option value="Notification">Notification</option>
+              <option value="Update">Update</option>
             </select>
           </div>
         </div>
@@ -55,7 +55,7 @@
         {% regroup health_alerts by alert_date.year as health_alert_list %}
         {% for year in health_alert_list %}
           <tr
-            data-priority="{% for alert in year.list %}{{ alert.priority }} {% endfor %}"
+            data-priority="{% for alert in year.list %}{{ alert.get_priority_display }} {% endfor %}"
             data-year="{{ year.grouper }}"
           >
             <td colspan="3" class="pl-0">
@@ -85,7 +85,7 @@
           {% for alert in year.list %}
             <tr
               class="{% if forloop.counter|divisibleby:2 %}row-bg-white-hip{% else %}row-bg-grey-hip{% endif %}"
-              data-priority="{{ alert.priority }}"
+              data-priority="{{ alert.get_priority_display }}"
             >
               <td class="topic"><a href="{{ alert.specific.alert_file.url }}">{{ alert.title }}</a></td>
               <td class="priority {{ alert.get_priority_display|lower }}-hip">

--- a/apps/hip/templates/hip/static_page.html
+++ b/apps/hip/templates/hip/static_page.html
@@ -18,9 +18,9 @@
         </div>
         {% for block in page.body %}
           {% if block.value.nav_heading %}
-	    {# This is the div that the IntersectionObserver observes #}
-	    <div class="nav-heading-hip" id="section-{{block.value.nav_heading|slugify}}"></div>
-	  {% endif %}
+            {# This is the div that the IntersectionObserver observes #}
+            <div class="nav-heading-hip" id="section-{{block.value.nav_heading|slugify}}"></div>
+          {% endif %}
           {% if block.value.is_card %}
             <section class="page-section-hip card-hip mt-4 mb-6 mx-4">
           {% else %}

--- a/apps/hip/templates/includes/health_alert_legend.html
+++ b/apps/hip/templates/includes/health_alert_legend.html
@@ -1,0 +1,53 @@
+<div class="dropdown-menu">
+  <div class="dropdown-content legend-hip">
+
+    <div class="dropdown-item">
+      <div class="columns is-vcentered">
+        <div class="column is-one-quarter alert-hip legend-left-hip">
+          <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+          Alert
+        </div>
+        <div class="column">
+          Conveys the highest level of importance; warrants immediate action or attention.
+        </div>
+      </div>
+    </div>
+
+    <div class="dropdown-item">
+      <div class="columns is-vcentered">
+        <div class="column is-one-quarter advisory-hip legend-left-hip">
+          <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+          Advisory
+        </div>
+        <div class="column">
+          Provides important information for a specific incident or situation; may not require immediate action.
+        </div>
+      </div>
+    </div>
+
+    <div class="dropdown-item">
+      <div class="columns is-vcentered">
+        <div class="column is-one-quarter notification-hip legend-left-hip">
+          <i class="fa fa-info-circle" aria-hidden="true"></i>
+          Notification
+        </div>
+        <div class="column">
+          Provides information regarding an incident or situation; unlikely to require immediate action.
+        </div>
+      </div>
+    </div>
+
+    <div class="dropdown-item">
+      <div class="columns is-vcentered">
+        <div class="column is-one-quarter update-hip legend-left-hip">
+          <i class="fa fa-arrow-alt-circle-up" aria-hidden="true"></i>
+          Update
+        </div>
+        <div class="column">
+          Provides updated information regarding an incident or situation; unlikely to require immediate action.
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -78,18 +78,18 @@ where `<environment>` represents the name of the environment you are updating, u
 
 1. Generate or obtain the new secret. Then encrypt it with this command:
 
-	```sh
-	(hip)$ cd deploy
-	(hip)$ ansible-vault encrypt_string <secret>
-	!vault |
-	          $ANSIBLE_VAULT;1.1;AES256
-			  38646465363539613435316335663835373561346262383832303439623533376564636465666535
-			  3663396663373465633465636639636631303232343732380a343034376633323330386337653930
-			  36643366636334643839363763366335343266643431346435636264623634616538373863393534
-			  3937643532306231610a626333656461386433303335373361323330323466666130303063303863
-			  30623762363233643337653961633062346537643066663837633535336164623663
+    ```sh
+    (hip)$ cd deploy
+    (hip)$ ansible-vault encrypt_string <secret>
+    !vault |
+              $ANSIBLE_VAULT;1.1;AES256
+              38646465363539613435316335663835373561346262383832303439623533376564636465666535
+              3663396663373465633465636639636631303232343732380a343034376633323330386337653930
+              36643366636334643839363763366335343266643431346435636264623634616538373863393534
+              3937643532306231610a626333656461386433303335373361323330323466666130303063303863
+              30623762363233643337653961633062346537643066663837633535336164623663
     Encryption successful
-	```
+    ```
 2. Copy everything from the `!vault` up until the `Encryption successful` message, but
    not including the `Encryption successful` message.
 
@@ -126,20 +126,20 @@ to the cluster.
 2. Verify that there is an entry in `~/.aws/credentials` for your Caktus Saguaro role.
    Your file should have both of the following entries:
 
-	```conf
-	[caktus]
-	aws_access_key_id = <your caktus account access key id>
-	aws_secret_access_key = <your caktus account secret access key>
+    ```conf
+    [caktus]
+    aws_access_key_id = <your caktus account access key id>
+    aws_secret_access_key = <your caktus account secret access key>
 
-	# ...
+    # ...
 
-	[saguaro-cluster]
-	role_arn = arn:aws:iam::472354598015:role/CaktusAccountAccessRole-Admins
-	source_profile = caktus
-	```
+    [saguaro-cluster]
+    role_arn = arn:aws:iam::472354598015:role/CaktusAccountAccessRole-Admins
+    source_profile = caktus
+    ```
 
-	This will allow you to use the special AWS Role that we have set up that gives
-	accounts in `caktus` full privileges in `saguaro-cluster`.
+    This will allow you to use the special AWS Role that we have set up that gives
+    accounts in `caktus` full privileges in `saguaro-cluster`.
 
 3. Set `AWS_PROFILE` to this named profile. This should be added to your environment
    (using whatever method you use for that: `.envrc`, `.env`, `magical-shell-script.sh`)
@@ -155,8 +155,8 @@ to the cluster.
     time to time, so you may have to re-run the command before a deploy.
 
     ```sh
-	(hip)$ echo $AWS_PROFILE
-	saguaro-cluster
+    (hip)$ echo $AWS_PROFILE
+    saguaro-cluster
     (hip)$ inv aws.docker-login
     ```
 
@@ -172,9 +172,9 @@ to the cluster.
 
 2. You should now have access via ``kubectl``:
 
-	```sh
-	(hip)$ kubectl get node
-	```
+    ```sh
+    (hip)$ kubectl get node
+    ```
 
 ## Useful Commands
 

--- a/docs/provision.md
+++ b/docs/provision.md
@@ -28,20 +28,20 @@ repo, but a copy has also been placed in the LastPass entry, "HIP Staging Secret
 2. Verify that there is an entry in `~/.aws/credentials` for your Caktus Saguaro role.
    Your file should have both of the following entries:
 
-	```conf
-	[caktus]
-	aws_access_key_id = <your caktus account access key id>
-	aws_secret_access_key = <your caktus account secret access key>
+    ```conf
+    [caktus]
+    aws_access_key_id = <your caktus account access key id>
+    aws_secret_access_key = <your caktus account secret access key>
 
-	# ...
+    # ...
 
-	[saguaro-cluster]
-	role_arn = arn:aws:iam::472354598015:role/CaktusAccountAccessRole-Admins
-	source_profile = caktus
-	```
+    [saguaro-cluster]
+    role_arn = arn:aws:iam::472354598015:role/CaktusAccountAccessRole-Admins
+    source_profile = caktus
+    ```
 
-	This will allow you to use the special AWS Role that gives accounts in `caktus` full
-	privileges in `saguaro-cluster`.
+    This will allow you to use the special AWS Role that gives accounts in `caktus` full
+    privileges in `saguaro-cluster`.
 
 3. Set `AWS_PROFILE` to this named profile. This should be added to your environment
    (using whatever method you use for that: `.envrc`, `.env`, `magical-shell-script.sh`)
@@ -100,64 +100,64 @@ repo, but a copy has also been placed in the LastPass entry, "HIP Staging Secret
 
     ```sh
     (hip)$ aws rds describe-db-instances
-	```
+    ```
 
    * From that output, get `MasterUsername`, `DBName`, and `Endpoint.Address`.
    * Get the `MasterPassword` from the LastPass entry, "Saguaro Cluster Secrets".
    * Choose or generate a `HipDbPassword` that you'll use for HIP. Save that
-	 somewhere so that you can encrypt it later in the process.
+     somewhere so that you can encrypt it later in the process.
 
 2. Using those parameters, create the DB with the proper permissions. (Anything in curly
    brackets is meant to represent a placeholder for the actual values from the step above):
 
-	```sh
-	(hip)$ inv pod.debian
-	root@debian:/# apt update && apt install postgresql-client -y
-	root@debian:/# psql postgres://{MasterUsername}:{MasterPassword}@{Endpoint.Address}:5432/{DBName}
-	=> CREATE DATABASE hip_staging;
-	=> CREATE ROLE hip_staging WITH LOGIN NOSUPERUSER INHERIT CREATEDB NOCREATEROLE NOREPLICATION PASSWORD '{HipDbPassword}';
-	=> GRANT CONNECT ON DATABASE hip_staging TO hip_staging;
-	=> GRANT ALL PRIVILEGES ON DATABASE hip_staging TO hip_staging;
-	```
+    ```sh
+    (hip)$ inv pod.debian
+    root@debian:/# apt update && apt install postgresql-client -y
+    root@debian:/# psql postgres://{MasterUsername}:{MasterPassword}@{Endpoint.Address}:5432/{DBName}
+    => CREATE DATABASE hip_staging;
+    => CREATE ROLE hip_staging WITH LOGIN NOSUPERUSER INHERIT CREATEDB NOCREATEROLE NOREPLICATION PASSWORD '{HipDbPassword}';
+    => GRANT CONNECT ON DATABASE hip_staging TO hip_staging;
+    => GRANT ALL PRIVILEGES ON DATABASE hip_staging TO hip_staging;
+    ```
 
 3. Once the DB is created, run a similar command to connect to it as the RDS superuser
    so that we can install the Postgresql citext extension:
 
    ```sh
-	(hip)$ inv pod.debian
-	root@debian:/# apt update && apt install postgresql-client -y
-	root@debian:/# psql postgres://{MasterUsername}:{MasterPassword}@{Endpoint.Address}:5432/hip_staging
-	=> CREATE EXTENSION citext;
+    (hip)$ inv pod.debian
+    root@debian:/# apt update && apt install postgresql-client -y
+    root@debian:/# psql postgres://{MasterUsername}:{MasterPassword}@{Endpoint.Address}:5432/hip_staging
+    => CREATE EXTENSION citext;
    ```
 
 ### Point your desired domain at the load balancer
 
 1. Find the load balancer URL:
 
-	```sh
-	(hip)$ kubectl get svc -n ingress-nginx
-	```
+    ```sh
+    (hip)$ kubectl get svc -n ingress-nginx
+    ```
 
 2. Copy the `EXTERNAL-IP` value from that output. It is the load balancer URL.
 
 3. Go to Cloudflare and create a CNAME from your desired subdomain pointing to that URL.
 
-	```
-	hip.caktus-built.com ->	a4c59174c7fff4935b9ab58abd1722e9-742984194.us-east-1.elb.amazonaws.com
-	```
+    ```
+    hip.caktus-built.com -> a4c59174c7fff4935b9ab58abd1722e9-742984194.us-east-1.elb.amazonaws.com
+    ```
 
 ### Set up vault password
 
 1. Generate a long password and save it to AWS with this command:
 
-	```sh
-	(hip)$ aws secretsmanager create-secret --name hip-ansible-vault-password --secret-string <long-secret>
-	{
-		"ARN": "arn:aws:secretsmanager:us-east-1:472354598015:secret:hip-ansible-vault-password-KxkJpW",
-		"Name": "hip-ansible-vault-password",
-		"VersionId": "35d97d2b-7130-407e-bd5c-e59f9d077234"
-	}
-	```
+    ```sh
+    (hip)$ aws secretsmanager create-secret --name hip-ansible-vault-password --secret-string <long-secret>
+    {
+        "ARN": "arn:aws:secretsmanager:us-east-1:472354598015:secret:hip-ansible-vault-password-KxkJpW",
+        "Name": "hip-ansible-vault-password",
+        "VersionId": "35d97d2b-7130-407e-bd5c-e59f9d077234"
+    }
+    ```
 
 2. Record the ARN that is returned, you'll need that for setting up CI later
 
@@ -193,13 +193,13 @@ complete that process.
    encrypted value in `deploy/host_vars/staging.yml` for `k8s_auth_api_key`.
 
      ```sh
-	 cd deploy
-	 ansible-vault encrypt_string <secret>
-	 ```
+     cd deploy
+     ansible-vault encrypt_string <secret>
+     ```
 
 5. Repeat step 4 for the other secrets that we need in `host_vars/staging.yaml`
     * `HipDbPassword` from above as `database_password`.
-	* Encrypt a long secret key and save it as
+    * Encrypt a long secret key and save it as
       `k8s_environment_variables/DJANGO_SECRET_KEY`.
 
 ### Set up email with Amazon SES
@@ -216,19 +216,19 @@ https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html
 
 1. Finally, do the deploy again, and it should work.
 
-	```sh
-	(hip)$ inv staging image deploy
-	```
+    ```sh
+    (hip)$ inv staging image deploy
+    ```
 
 2. Confirm that you see pods running in our namespace.
 
-	```sh
-	(hip)$ kubectl get pods --namespace=hip-staging
-	NAME                         READY   STATUS    RESTARTS   AGE
-	app-84f486b849-pfp7k         1/1     Running   0          5m
-	app-84f486b849-zdjlz         1/1     Running   0          5m
-	memcached-797d6b546c-fn862   1/1     Running   0          7m
-	```
+    ```sh
+    (hip)$ kubectl get pods --namespace=hip-staging
+    NAME                         READY   STATUS    RESTARTS   AGE
+    app-84f486b849-pfp7k         1/1     Running   0          5m
+    app-84f486b849-zdjlz         1/1     Running   0          5m
+    memcached-797d6b546c-fn862   1/1     Running   0          7m
+    ```
 
 ### Create S3 buckets for media and assets
 

--- a/hip/static/js/index.js
+++ b/hip/static/js/index.js
@@ -23,6 +23,7 @@ import Header from "../../../apps/hip/static/js/header";
 import SideBar from "../../../apps/hip/static/js/sidebar";
 import RightScrollNav from "../../../apps/hip/static/js/rightScrollNav";
 import MobileSearchModal from "../../../apps/hip/static/js/mobileSearchModal";
+import HealthAlertPriorityFilter from "../../../apps/health_alerts/static/js/healthAlertPriorityFilter";
 
 document.addEventListener("DOMContentLoaded", function() {
   Common();
@@ -30,4 +31,5 @@ document.addEventListener("DOMContentLoaded", function() {
   SideBar();
   MobileSearchModal();
   RightScrollNav();
+  HealthAlertPriorityFilter();
 });

--- a/hip/static/styles/bundle.scss
+++ b/hip/static/styles/bundle.scss
@@ -22,6 +22,7 @@ This file will manage all scss file imports.
 @import "./includes/sidebar";
 @import "./includes/right_scroll_nav";
 @import "./includes/mobile_search_modal.scss";
+@import "./includes/health_alert_legend.scss";
 
 // ----------------- Includes Imports ---------------- //
 

--- a/hip/static/styles/includes/health_alert_legend.scss
+++ b/hip/static/styles/includes/health_alert_legend.scss
@@ -1,0 +1,6 @@
+.legend-hip {
+  width: 34rem;
+}
+.legend-left-hip {
+  font-size: 16px;
+}

--- a/hip/static/styles/pages/health_alert_index_page.scss
+++ b/hip/static/styles/pages/health_alert_index_page.scss
@@ -10,22 +10,45 @@
 
 .alert-table-hip {
   width: 100%;
-  border: 0;
   border-spacing: 2px 0;
   border-collapse: separate;
+
   th {
     background-color: $dark-grey;
     color: $white;
     border-width: 0;
+    height: 3.5rem;
+    vertical-align: middle;
   }
+
   td {
     border-width: 0;
+    vertical-align: middle;
   }
 
   .row-bg-white-hip {
     background-color: $white;
   }
+
   .row-bg-grey-hip {
     background-color: $light-grey;
+  }
+
+  .year-hip {
+    color: $grey;
+    font-weight: 700;
+  }
+
+  .topic {
+    font-size: 18px;
+  }
+
+  .priority {
+    width: 12rem;
+    text-transform: uppercase;
+  }
+
+  .alert-date {
+    width: 12rem;
   }
 }

--- a/hip/static/styles/pages/health_alert_index_page.scss
+++ b/hip/static/styles/pages/health_alert_index_page.scss
@@ -24,6 +24,7 @@
   td {
     border-width: 0;
     vertical-align: middle;
+    overflow-wrap: break-word;
   }
 
   .row-bg-white-hip {


### PR DESCRIPTION
I just noticed that on my new laptop, I had not configured tabs to be converted to spaces (:cone-of-shame:).

First commit: 
* converts tabs to spaces in the files I have committed

Second commit:
* Adds the hoverable legend on desktop only (as an include, so as not to clutter the template, and so it might be reused for the home page recent updates section if needed later)
* Aligns the year headings properly, makes them bold and gray
* Makes the table column widths match the mockup better (last 2 columns smaller than the first)
* Makes the table header slightly taller and vertical aligns the content inside of them
* Makes the topic 18px font, slightly larger than the other 2 columns
* Makes priority uppercase

Third commit:
* Styles the filter (no shadow, aligned properly with other items on the page)
* Adds a working JS-only filter that properly filters rows (including the year header if no matching rows in that year are desired), restripes the rows, and filters the right side links if needed