### PR TITLE
HP-25-styling Begin styling the disease page

### DIFF
--- a/apps/disease_control/templates/disease_control/disease_page.html
+++ b/apps/disease_control/templates/disease_control/disease_page.html
@@ -92,17 +92,17 @@
         {% endif %}
         <h3>For Patients and Community Members:</h3>
         <div>
-	  <ul>
+	  <div>
 	    {% for document in documents %}
-	      <li>
-                <a href="{{ document.url }}">{{ document.title }}
-                  <span class="pdf-icon-hip"></span>
-                </a>
-              </li>
-            {% empty %}
-              <li>There are no patient or community resources for {{ page.title }}.</li>
+	      <p>
+          <a href="{{ document.url }}"><strong>{{ document.title }}</strong>
+            <span class="pdf-icon-hip pl-2 is-size-6"></span>
+          </a>
+        </p>
+      {% empty %}
+        <p>There are no patient or community resources for {{ page.title }}.<p>
 	    {% endfor %}
-	  </ul>
+    </div>
         </div>
       </div>
     </div>

--- a/apps/disease_control/templates/disease_control/disease_page.html
+++ b/apps/disease_control/templates/disease_control/disease_page.html
@@ -11,11 +11,17 @@
         <h2>{{ page.title }}</h2>
 
         {% if page.at_a_glance %}
-          {{ page.at_a_glance|richtext }}
+          <div class="at-a-glance-hip">
+            <h3>At a Glance</h3>
+            {{ page.at_a_glance|richtext }}
+          </div>
         {% endif %}
 
         {% if page.current_recommendations %}
-          {{ page.current_recommendations|richtext }}
+          <div class="current-recommendations-hip">
+            <h3>Current Recommendations</h3>
+            {{ page.current_recommendations|richtext }}
+          </div>
         {% endif %}
 
         <div class="nav-heading-hip" id="section-{{ "Health Alerts"|slugify }}"></div>
@@ -82,13 +88,19 @@
         {% if page.provider_resources %}
           {{ page.provider_resources|richtext }}
         {% else %}
-          There are no resources regarding {{ page.title }} for healthcare providers.
+          There are no healthcare provider resources available for {{ page.title }}.
         {% endif %}
         <h3>For Patients and Community Members:</h3>
         <div>
 	  <ul>
 	    {% for document in documents %}
-	      <li><a href="{{ document.url }}">{{ document.title }}</a></li> <!-- FIXME: Add document icon -->
+	      <li>
+                <a href="{{ document.url }}">{{ document.title }}
+                  <span class="pdf-icon-hip"></span>
+                </a>
+              </li>
+            {% empty %}
+              <li>There are no patient or community resources for {{ page.title }}.</li>
 	    {% endfor %}
 	  </ul>
         </div>

--- a/apps/hip/wagtail_hooks.py
+++ b/apps/hip/wagtail_hooks.py
@@ -1,7 +1,17 @@
-from django.utils.html import format_html
+from django.utils.html import escape, format_html
 
 from sass_processor.processor import sass_processor
 from wagtail.core import hooks
+from wagtail.core.rich_text import LinkHandler
+
+
+class ExternalLinkHandler(LinkHandler):
+    identifier = "external"
+
+    @classmethod
+    def expand_db_attributes(cls, attrs):
+        href = attrs["href"]
+        return f'<a href="{escape(href)}" class="external-linktype">'
 
 
 @hooks.register("insert_editor_css")
@@ -11,3 +21,8 @@ def editor_css():
         '<link rel="stylesheet" href="{}">',
         sass_processor("styles/wagtail_styles.scss"),
     )
+
+
+@hooks.register("register_rich_text_features")
+def register_external_link(features):
+    features.register_link_type(ExternalLinkHandler)

--- a/hip/static/styles/_mixins.scss
+++ b/hip/static/styles/_mixins.scss
@@ -19,17 +19,19 @@
   };
 }
 
+@mixin a-tags {
+  a {
+    color: $dark-blue;
+  }
+}
+
+
 @mixin paragraphs {
   p {
     padding: 0.5rem 0;
     line-height: $line-height;
     max-width: 50rem;
-  }
-}
-
-@mixin a-tags {
-  a {
-    color: $dark-blue;
+    @include a-tags;
   }
 }
 
@@ -39,16 +41,18 @@
     padding: 0;
     margin: 0;
     li {
-      display: block;
+      display: inline-block;
+      vertical-align: middle;
       margin-left: 1rem;
       line-height: $line-height;
+      @include a-tags;
       &:before {
         content: "•";
-        vertical-align: middle;
         display: inline-block;
+        vertical-align: middle;
         color: $grey;
         font-size: 2rem;
-        margin-right: 0.75rem;
+        margin-right: 0.5rem;
         margin-bottom: 0rem;
       }
     }

--- a/hip/static/styles/_mixins.scss
+++ b/hip/static/styles/_mixins.scss
@@ -1,13 +1,6 @@
 @import "./colors";
 @import "./variables";
 
-@mixin links {
-  outline: none;
-  text-decoration: none;
-  color: inherit;
-  cursor: pointer;
-}
-
 @mixin headers {
   h2 {
     font-size: $is-size-2;
@@ -29,7 +22,36 @@
 @mixin paragraphs {
   p {
     padding: 0.5rem 0;
+    line-height: $line-height;
     max-width: 50rem;
+  }
+}
+
+@mixin a-tags {
+  a {
+    color: $dark-blue;
+  }
+}
+
+@mixin lists {
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    li {
+      display: block;
+      margin-left: 1rem;
+      line-height: $line-height;
+      &:before {
+        content: "•";
+        vertical-align: middle;
+        display: inline-block;
+        color: $grey;
+        font-size: 2rem;
+        margin-right: 0.75rem;
+        margin-bottom: 0rem;
+      }
+    }
   }
 }
 

--- a/hip/static/styles/_variables.scss
+++ b/hip/static/styles/_variables.scss
@@ -25,3 +25,6 @@ $breakpoint-mobile: 768px;
 $breakpoint-tablet: 1023px;
 $breakpoint-desktop: 1215px;
 $breakpoint-widescreen: 1407px;
+
+// Line height of paragraphs and lists (see _mixins.scss for use)
+$line-height: 2rem;

--- a/hip/static/styles/common.scss
+++ b/hip/static/styles/common.scss
@@ -1,4 +1,5 @@
 @import "./mixins";
+@import "./icons.scss";
 @import "./colors";
 
 // ---------------- Background Colors ----------- //
@@ -97,4 +98,10 @@ body.modal-is-open-hip {
   height: 100vh;
   overflow-y: hidden;
   padding-right: 15px;
+}
+
+// ------------------- Wagtail Generated Links ------------------ //'
+
+.external-linktype {
+  @include external-link-icon($before: false);
 }

--- a/hip/static/styles/icons.scss
+++ b/hip/static/styles/icons.scss
@@ -1,5 +1,6 @@
 @import "../font_awesome/scss/fontawesome.scss";
 @import "../font_awesome/scss/solid.scss";
+@import "../font_awesome/scss/regular.scss";
 @import "./colors";
 
 /* Adding a new icon
@@ -22,6 +23,11 @@ To select that icon, do:
 @mixin solid-icon {
   @extend %fa-icon; // font-awesome icon
   @extend .fas; // solid icon
+}
+
+@mixin regular-icon {
+  @extend %fa-icon; // font-awesome icon
+  @extend .far; // regular icon
 }
 
 .search-icon-hip {
@@ -125,6 +131,14 @@ To select that icon, do:
   @include solid-icon;
   &::before {
     content: fa-content($fa-var-external-link-alt);
+  }
+}
+
+.pdf-icon-hip {
+  color: $dark-blue;
+  @include regular-icon;
+  &::before {
+    content: fa-content($fa-var-file-pdf);
   }
 }
 

--- a/hip/static/styles/icons.scss
+++ b/hip/static/styles/icons.scss
@@ -30,6 +30,21 @@ To select that icon, do:
   @extend .far; // regular icon
 }
 
+@mixin external-link-icon($before: true) {
+  color: $dark-blue;
+  @include solid-icon;
+  @if $before {
+    &::before {
+      content: fa-content($fa-var-external-link-alt);
+    }
+  } @else {
+    &::after {
+      content: fa-content($fa-var-external-link-alt);
+      margin-left: 0.5rem;
+    }
+  }
+}
+
 .search-icon-hip {
   color: $white;
   @include solid-icon;

--- a/hip/static/styles/includes/disease_control_card.scss
+++ b/hip/static/styles/includes/disease_control_card.scss
@@ -1,4 +1,5 @@
 @import "../colors";
+@import "../mixins";
 
 .disease-control-card-hip {
   border-bottom: 2px solid $light-grey;
@@ -21,21 +22,6 @@
     p {
       color: $black;
     }
-    ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      li {
-        display: flex;
-        margin-left: 1rem;
-        &:before {
-          content: "•";
-          display: block;
-          color: $grey;
-          font-size: 2rem;
-          margin-right: 0.5rem;
-        }
-      }
-    }
+    @include lists;
   }
 }

--- a/hip/static/styles/includes/header.scss
+++ b/hip/static/styles/includes/header.scss
@@ -11,7 +11,10 @@
 }
 
 .logo-hip {
-  @include links;
+  outline: none;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
   height: 100%;
   width: 300px;
   display: inline-block;

--- a/hip/static/styles/pages/disease_page.scss
+++ b/hip/static/styles/pages/disease_page.scss
@@ -4,4 +4,19 @@
 .disease-page-hip {
   margin: 0 3rem;
   @include headers;
+
+  .at-a-glance-hip {
+    background-color: $light-grey;
+    padding: 0.25rem 1rem 1rem 1rem;
+    border-left: 1rem solid $orange;
+    margin-top: 2rem;
+  }
+
+  .current-recommendations-hip {
+    background-color: $light-grey;
+    padding: 0.25rem 1rem 1rem 1rem;
+    border-left: 1rem solid $purple;
+    margin-top: 2rem;
+  }
+
 }

--- a/hip/static/styles/pages/disease_page.scss
+++ b/hip/static/styles/pages/disease_page.scss
@@ -4,6 +4,9 @@
 .disease-page-hip {
   margin: 0 3rem;
   @include headers;
+  @include paragraphs;
+  @include lists;
+  @include a-tags;
 
   .at-a-glance-hip {
     background-color: $light-grey;

--- a/hip/static/styles/pages/static_page.scss
+++ b/hip/static/styles/pages/static_page.scss
@@ -5,6 +5,7 @@
   @include headers;
   @include paragraphs;
   @include tables;
+  @include a-tags;
 }
 
 .card-hip {

--- a/hip/static/styles/pages/static_page.scss
+++ b/hip/static/styles/pages/static_page.scss
@@ -5,7 +5,6 @@
   @include headers;
   @include paragraphs;
   @include tables;
-  @include a-tags;
 }
 
 .card-hip {


### PR DESCRIPTION
This adds styles for the "at a glance" and "current recommendations" boxes at the top, and adds icons next to the documents at the bottom of the page. (Note this is a change from the AC... instead of showing thumbnails for the patient/community resources, we are just listing them with icons next to them)

Still needed:
- [x] making sure that links in user-edited content are shown with the external link icon
- [x] making sure that lists in user-edited content preserve the list circle at the beginning
- [x] other tweaks?