### PR TITLE
fix text inside of wagtail hook

### DIFF
--- a/apps/hip/wagtail_hooks.py
+++ b/apps/hip/wagtail_hooks.py
@@ -11,7 +11,7 @@ class ExternalLinkHandler(LinkHandler):
     @classmethod
     def expand_db_attributes(cls, attrs):
         href = attrs["href"]
-        return f'<span class="external-linktype"><a href="{escape(href)}" class="fix-text-hip">'
+        return f'<a href="{escape(href)}" class="external-linktype">'
 
 
 @hooks.register("insert_editor_css")

--- a/apps/hip/wagtail_hooks.py
+++ b/apps/hip/wagtail_hooks.py
@@ -11,7 +11,7 @@ class ExternalLinkHandler(LinkHandler):
     @classmethod
     def expand_db_attributes(cls, attrs):
         href = attrs["href"]
-        return f'<a href="{escape(href)}" class="external-linktype">'
+        return f'<span class="external-linktype"><a href="{escape(href)}" class="fix-text-hip">'
 
 
 @hooks.register("insert_editor_css")

--- a/hip/static/js/common.js
+++ b/hip/static/js/common.js
@@ -1,5 +1,6 @@
 export default function () {
   manageDocumentLinks();
+  addExternalLinkIcons();
 
   function manageDocumentLinks () {
     /* Manage Document Links
@@ -27,4 +28,17 @@ export default function () {
       }
     });
   }
+
+  function addExternalLinkIcons () {
+    /* Add External Link Icons to Wagtail Hook Generated Links of
+    type external across the site.
+    */
+   const externalLinks = Array.from(document.querySelectorAll('a.external-linktype'));
+   for (const link of externalLinks) {
+     const span = document.createElement("span");
+     span.classList.add("external-link-icon-hip");
+     span.classList.add("pl-2");
+     link.appendChild(span);
+   };
+  };
 };

--- a/hip/static/styles/common.scss
+++ b/hip/static/styles/common.scss
@@ -99,9 +99,3 @@ body.modal-is-open-hip {
   overflow-y: hidden;
   padding-right: 15px;
 }
-
-// ------------------- Wagtail Generated Links ------------------ //'
-
-.fix-text-hip {
-  font-family: "Open Sans", "sans-serif";
-}

--- a/hip/static/styles/common.scss
+++ b/hip/static/styles/common.scss
@@ -102,6 +102,9 @@ body.modal-is-open-hip {
 
 // ------------------- Wagtail Generated Links ------------------ //'
 
+.fix-text-hip {
+  font-family: "Open Sans", "sans-serif";
+}
 .external-linktype {
   @include external-link-icon($before: false);
 }

--- a/hip/static/styles/common.scss
+++ b/hip/static/styles/common.scss
@@ -105,6 +105,3 @@ body.modal-is-open-hip {
 .fix-text-hip {
   font-family: "Open Sans", "sans-serif";
 }
-.external-linktype {
-  @include external-link-icon($before: false);
-}


### PR DESCRIPTION
Fix to make sure wagtail hook external links have the same font-family as the result of the site (override Font Awesome Free) font family.