### PR TITLE
[HP-52] Limit Documents To PDF, PNG, JPG

### DIFF
--- a/hip/settings/base.py
+++ b/hip/settings/base.py
@@ -256,6 +256,8 @@ WAGTAILSEARCH_BACKENDS = {
     },
 }
 
+WAGTAILDOCS_EXTENSIONS = ["doc", "png", "jpg"]
+
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash

--- a/hip/settings/base.py
+++ b/hip/settings/base.py
@@ -256,7 +256,7 @@ WAGTAILSEARCH_BACKENDS = {
     },
 }
 
-WAGTAILDOCS_EXTENSIONS = ["doc", "png", "jpg"]
+WAGTAILDOCS_EXTENSIONS = ["pdf", "png", "jpg"]
 
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-52

This pull request limits `Document` uploads to files that have either a .pdf, .png, or a .jpg extension. As a note, I find it surprising that the error only shows up after the document claims to have uploaded (step 2), but it's Wagtail's functionality, so I decided to not change it, and we can see how it does in QA.