### PR TITLE
Allow DiseasePage.description To Be Editable In Wagtail Again

### DIFF
--- a/apps/disease_control/models.py
+++ b/apps/disease_control/models.py
@@ -100,6 +100,7 @@ class DiseasePage(Page):
 
     content_panels = [
         FieldPanel("title"),
+        FieldPanel("description"),
         FieldPanel("at_a_glance"),
         FieldPanel("current_recommendations"),
         FieldPanel("surveillance"),


### PR DESCRIPTION
by adding it to the `DiseasePage`'s `content_panels`.