### PR TITLE
HP-100 Move the header below the first year

### DIFF
--- a/apps/health_alerts/static/js/healthAlertFilter.js
+++ b/apps/health_alerts/static/js/healthAlertFilter.js
@@ -2,6 +2,7 @@ export default function() {
   const hasHealthAlerts = document.querySelector('.alert-table-hip');
   const selectConditionEl = document.querySelector('.select-condition');
   const alertsMissingEl = document.querySelector(".alerts-missing-hip");
+  const tableHeaderEl = document.querySelector(".alert-table-header-hip");
   const allRows = document.querySelectorAll("[data-condition]");
   // the select element is only on the health alerts page
   const isHealthAlertsPage = selectConditionEl;
@@ -68,6 +69,10 @@ export default function() {
       alertsMissingEl.hidden = false;
     } else {
       alertsMissingEl.hidden = true;
+      // we have at least 1 row. make sure that the header and "no alerts row" are shown
+      // after the first row, which is the first "year" row
+      rowsToShow[0].after(tableHeaderEl);
+      tableHeaderEl.after(alertsMissingEl);
     }
   }
 

--- a/apps/hip/templates/includes/health_alert_table_header.html
+++ b/apps/hip/templates/includes/health_alert_table_header.html
@@ -1,4 +1,4 @@
-<tr>
+<tr class="alert-table-header-hip">
   <th>Topic</th>
   <th>
     <span class="is-mobile desktop-hidden-hip">Priority</span>
@@ -12,8 +12,8 @@
   </th>
   <th>Date of Alert</th>
 </tr>
-<tr>
-  <td class="alerts-missing-hip" colspan="3" hidden>
+<tr class="alerts-missing-hip" hidden>
+  <td colspan="3">
     No Health Alerts Found
   </td>
 </tr>


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-100

This moves the table header to be right after the first year, and it moves our "no alerts found" row to be just under the table header row as well. I don't think that there is any situation where the "no alerts row" will actually show up now on the main health alerts page.