### PR TITLE
Rename Incorrectly Named Factory

### DIFF
--- a/apps/emergency_response/tests/factories.py
+++ b/apps/emergency_response/tests/factories.py
@@ -4,7 +4,7 @@ import wagtail_factories
 from ..models import EmergencyResponsePage
 
 
-class EmergentHealthTopicsPageFactory(wagtail_factories.PageFactory):
+class EmergencyResponsePageFactory(wagtail_factories.PageFactory):
     title = factory.faker.Faker("sentence")
     description = factory.faker.Faker("text")
 


### PR DESCRIPTION
A previous pull request incorrectly named the `EmergencyResponsePageFactory` as `EmergentHealthTopicsPageFactory` due to copy/pasting.