### PR TITLE
[HP-109] Fix Health Alert Signup On Disease Page

### DIFF
--- a/apps/disease_control/templates/disease_control/disease_and_condition_detail_page.html
+++ b/apps/disease_control/templates/disease_control/disease_and_condition_detail_page.html
@@ -40,7 +40,7 @@
           {# Sign up button is on the right #}
           <div class="level-right">
             <div class="level-item">
-              <a href="/fixme-alert-signup" class="is-block">
+              <a href="{% url 'health_alert_subscriber' %}" class="is-block">
                 <span class="button is-size-7-touch header-icon-hip">
                   <i class="email-icon-hip"></i>
                 </span>

--- a/apps/health_alerts/templates/health_alerts/health_alert_list_page.html
+++ b/apps/health_alerts/templates/health_alerts/health_alert_list_page.html
@@ -19,7 +19,7 @@
           {# Sign up button is on the right #}
           <div class="level-right">
             <div class="level-item">
-              <a href="/health-alerts-subscriber-signup" class="is-block">
+              <a href="{% url 'health_alert_subscriber' %}" class="is-block">
                 <span class="button is-size-7-touch header-icon-hip">
                   <i class="email-icon-hip"></i>
                 </span>

--- a/apps/health_alerts/templates/health_alerts/health_alert_subscriber.html
+++ b/apps/health_alerts/templates/health_alerts/health_alert_subscriber.html
@@ -15,7 +15,7 @@
     </div>
     <div class="px-4 columns is-widescreen">
       {# Sign Up Form Section #}
-      <form class="column is-half-desktop" action="/health-alerts-subscriber-signup" method="post">
+      <form class="column is-half-desktop" action="{% url 'health_alert_subscriber' %}" method="post">
         {% csrf_token %}
         <div>
           {% include 'includes/field_errors.html' with errors=form.non_field_errors %}

--- a/hip/urls.py
+++ b/hip/urls.py
@@ -16,7 +16,7 @@ from apps.search import views as search_views
 urlpatterns = [
     path("search/", search_views.search, name="search"),
     path(
-        "health-alerts-subscriber-signup",
+        "health-alerts-subscriber-signup/",
         health_alert_views.subscribe,
         name="health_alert_subscriber",
     ),


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-109

This pull request:
 - updates the link from the disease detail page to the health alerts signup page to be the real link
 - updates other template files that have a link to the health alerts signup page to use Django's `url` template tag
 - adds a trailing slash at the end of the `health_alert_subscriber` URL path