### PR TITLE
[HP-112] Disaply Link Icon For Non-Health-Alert Pages

### DIFF
--- a/apps/hip/templates/includes/search_result_card.html
+++ b/apps/hip/templates/includes/search_result_card.html
@@ -14,7 +14,7 @@
         </div>
         <div class="level-right">
           {% if result.specific.get_priority_display %}
-            {# Health alert pages show the icon for their priority and their priority #}
+            {# Health alert pages show the icon for their priority and the word to describe their priority #}
             <div class="level-item search-page-priority-badge-hip {{ result.specific.get_priority_display|slugify }}-hip">
               <i class="fa {{ result.specific.get_priority_icon }} pr-2"></i>
               {{ result.specific.get_priority_display|upper }}

--- a/apps/hip/templates/includes/search_result_card.html
+++ b/apps/hip/templates/includes/search_result_card.html
@@ -14,9 +14,16 @@
         </div>
         <div class="level-right">
           {% if result.specific.get_priority_display %}
+            {# Health alert pages show the icon for their priority and their priority #}
             <div class="level-item search-page-priority-badge-hip {{ result.specific.get_priority_display|slugify }}-hip">
               <i class="fa {{ result.specific.get_priority_icon }}"></i>
               {{ result.specific.get_priority_display|upper }}
+            </div>
+          {% else %}
+            {# Non-health-alert pages show the page icon and the word 'PAGE' #}
+            <div class="level-item search-page-priority-badge-hip">
+              <i class="fa fa-link pr-2" aria-hidden="true"></i>
+              PAGE
             </div>
           {% endif %}
         </div>


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-112

This pull request adds the link icon and the word 'PAGE' to each card in the search results that is not a health alert page.