### PR TITLE
Use Django's Url Template Tag For Login & Logout URLs In Templates

### DIFF
--- a/apps/emergency_response/templates/includes/partner_login_card.html
+++ b/apps/emergency_response/templates/includes/partner_login_card.html
@@ -8,7 +8,7 @@
       <li>Big City Public Health Preparedness Directors</li>
     </ul>
   </div>
-  <a href="/accounts/login/" class="is-block py-4">
+  <a href="{% url 'login' %}" class="is-block py-4">
     <span class="button login-icon-hip ml-0">
       <i class="signin-icon-hip"></i>
     </span>

--- a/apps/hip/templates/includes/header.html
+++ b/apps/hip/templates/includes/header.html
@@ -56,14 +56,14 @@
         </div>
         <div class="navbar-item">
           {% if request.user.is_authenticated %}
-            <a href="/accounts/logout/" class="is-block">
+            <a href="{% url 'logout' %}" class="is-block">
               <span class="button is-size-7-touch alt-header-btn-hip ml-0 pr-6">
                 <strong>Logged In</strong>
                 <i class="down-triangle-icon-hip"></i>
               </span>
             </a>
           {% else %}
-            <a href="/accounts/login/" class="is-block">
+            <a href="{% url 'login' %}" class="is-block">
               <span class="button is-size-7-touch header-icon-hip ml-0">
                 <i class="signin-icon-hip"></i>
               </span>
@@ -88,14 +88,14 @@
         </div>
         <div class="navbar-item pl-1 pr-2">
           {% if request.user.is_authenticated %}
-            <a href="/accounts/logout/" class="is-block">
+            <a href="{% url 'logout' %}" class="is-block">
               <span class="button is-size-7-touch alt-header-btn-hip ml-0">
                 <strong>Logged In</strong>
                 <i class="down-triangle-icon-hip"></i>
               </span>
             </a>
           {% else %}
-            <a href="/accounts/login/" class="is-block pr-6">
+            <a href="{% url 'login' %}" class="is-block pr-6">
               <span class="button is-size-7-touch header-icon-hip ml-0">
                 <i class="signin-icon-hip"></i>
               </span>


### PR DESCRIPTION
This pull request changes hard-coded login & logout URLs in templates to use Django's `url` template tag with the URL's name.