### PR TITLE
Make Logout Button Icon Show Up In Template

### DIFF
--- a/apps/hip/templates/includes/header.html
+++ b/apps/hip/templates/includes/header.html
@@ -59,7 +59,7 @@
             <a href="{% url 'logout' %}" class="is-block">
               <span class="button is-size-7-touch alt-header-btn-hip ml-0 pr-6">
                 <strong>Logged In</strong>
-                <i class="down-triangle-icon-hip"></i>
+                <i class="down-triangle-icon-hip pl-1 pb-1"></i>
               </span>
             </a>
           {% else %}
@@ -91,7 +91,7 @@
             <a href="{% url 'logout' %}" class="is-block">
               <span class="button is-size-7-touch alt-header-btn-hip ml-0">
                 <strong>Logged In</strong>
-                <i class="down-triangle-icon-hip"></i>
+                <i class="down-triangle-icon-hip pl-1 pb-1"></i>
               </span>
             </a>
           {% else %}

--- a/hip/static/styles/icons.scss
+++ b/hip/static/styles/icons.scss
@@ -159,7 +159,7 @@ To select that icon, do:
 
 .down-triangle-icon-hip {
   color: $dark-blue;
-  @include regular-icon;
+  @include solid-icon;
   &::before {
     content: fa-content($fa-var-sort-down);
   }


### PR DESCRIPTION
This pull request makes the logout icon show up in the template by using the correct mixin in the `icons.scss` file. Also, the icon now has a little padding, in order to match the wireframe.