### PR TITLE
HP-120

### DIFF
--- a/apps/hip/templates/includes/sidebar.html
+++ b/apps/hip/templates/includes/sidebar.html
@@ -1,4 +1,4 @@
-<div id="sidebarContent" class="column is-2-desktop sidebar-hip pr-0 my-0 is-hidden-touch">
+<div id="sidebarContent" class="column is-2-desktop sidebar-hip pr-0 my-0 is-hidden-touch {% if hidden_column_desktop %}is-hidden-desktop{% endif %}">
   <div class="desktop-hidden-hip my-0 {% if hidden_desktop %}is-hidden-desktop{% endif %}">
     <div class="is-flex is-justify-content-space-between is-vcentered">
       <h6 class="is-size-6 pt-2 pl-4"><strong>Menu</strong></h6>

--- a/apps/hip/templates/registration/login.html
+++ b/apps/hip/templates/registration/login.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block sidebar %}
+  {% include 'includes/sidebar.html' with hidden_column_desktop=True %}
+{% endblock %}
+
 {% block content %}
 <div class="login-page-hip columns px-5">
   <div class="column is-half is-offset-one-quarter">


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-120

Sidebar being hidden for the login screen is slightly different than it being hidden for the report a disease page. Dev's are now able to pass `hidden_column_desktop=True` to hide the column and right border of the sidebar on desktop devices.