### PR TITLE
HP-122 & HP-124

### DIFF
--- a/apps/hip/templates/registration/login.html
+++ b/apps/hip/templates/registration/login.html
@@ -1,16 +1,12 @@
 {% extends "base.html" %}
 
 {% block sidebar %}
-  {% include 'includes/sidebar.html' with hidden_column_desktop=True %}
+  {% include 'includes/sidebar.html' %}
 {% endblock %}
 
 {% block content %}
 <div class="login-page-hip columns px-5">
   <div class="column is-half is-offset-one-quarter">
-    <div class="pt-5">
-      <a href="{{ previous_url }}">< Back</a>
-    </div>
-
     <h2 class="pb-5">Response Partner Log In</h2>
 
     {% if form.errors %}


### PR DESCRIPTION
- Remove back button and add sidebar back to desktop

As a team we have decided to keep the `sidebar` as visible on the `login.html` page and the `password_reset.html` page. The `< Back` button has been removed from the `login.html`. Both the `login.html` and `password_reset.html` page should fully resemble each other. 