### PR TITLE
Add Search Description to HomePage and StaticPage Content Panels

### DIFF
--- a/apps/hip/models.py
+++ b/apps/hip/models.py
@@ -113,8 +113,7 @@ class StaticPage(HipBasePage):
         ]
     )
 
-    content_panels = [
-        FieldPanel("title"),
+    content_panels = HipBasePage.content_panels + [
         StreamFieldPanel("body"),
     ]
     promote_panels = [
@@ -208,8 +207,7 @@ class HomePage(HipBasePage):
         "Contact", null=True, blank=True, on_delete=models.SET_NULL, related_name="+"
     )
 
-    content_panels = [
-        FieldPanel("title"),
+    content_panels = HipBasePage.content_panels + [
         FieldPanel("short_description"),
         SnippetChooserPanel("contact_info"),
         StreamFieldPanel("quick_links"),


### PR DESCRIPTION
This pull request makes the `HomePage` and `StaticPage` inherit `content_panels` from `HipBasePage`, which adds the search description to the fields that the CMS user can edit in the content panel.