### PR TITLE
[HP-135] Give Icon Same Height As Text

### DIFF
--- a/apps/auth_content/templates/auth_content/closed_pod_home_page.html
+++ b/apps/auth_content/templates/auth_content/closed_pod_home_page.html
@@ -8,7 +8,7 @@
   {% if page.action_section %}
     <section class="action-section-hip py-4 pl-4">
       {{ page.action_section|richtext }}
-      <span class="button is-size-7-touch header-icon-hip ml-0">
+      <span class="button header-icon-hip ml-0">
         <i class="contact-icon-hip"></i>
       </span>
       <span class="button login-btn-hip ml-0">


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-135

This pull request removes the 'is-size-7-touch' CSS class from the contact info icon on the Closed POD homepage, so its height matches the height of the button with the text.