### PR TITLE
[HP-132] Don't Limit Paragraph Width

### DIFF
--- a/hip/static/styles/_mixins.scss
+++ b/hip/static/styles/_mixins.scss
@@ -31,7 +31,6 @@
   p {
     padding: 0.5rem 0;
     line-height: $line-height;
-    max-width: 50rem;
     @include a-tags;
   }
 }


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-132

This pull request takes away the limit for a paragraph's maximum width. After checking all affected pages (`DataReportDetailPage`, `PCWMSAHomePage`, `ClosedPODHomePage`, also a number of pages with a right-side navbar, like the `StaticPage`), it seems that paragraphs are already limited in their width by their parent, so this restriction doesn't seem necessary.