### PR TITLE
[HP-139] Report Detail Page Rightnav Styles

### DIFF
--- a/apps/hip/templates/hip/static_page.html
+++ b/apps/hip/templates/hip/static_page.html
@@ -11,9 +11,9 @@
 
 {% block content %}
   <div class="{% block page_css_class_class %}{% endblock %}">
-    {% block before_staticpage_content %}{% endblock %}
     <div class="columns">
       <div class="column">
+        {% block before_staticpage_content %}{% endblock %}
 
         {% block back_button %}
         <div class="pt-5 px-5">

--- a/apps/hip/templates/hip/static_page.html
+++ b/apps/hip/templates/hip/static_page.html
@@ -12,7 +12,7 @@
 {% block content %}
   <div class="{% block page_css_class_class %}{% endblock %}">
     <div class="columns">
-      <div class="column">
+      <div class="column {% block main_area_css_class %}{% endblock main_area_css_class %}">
         {% block before_staticpage_content %}{% endblock %}
 
         {% block back_button %}

--- a/apps/reports/templates/reports/data_report_detail_archive_detail_page.html
+++ b/apps/reports/templates/reports/data_report_detail_archive_detail_page.html
@@ -4,7 +4,7 @@
   {% include 'includes/sidebar.html' %}
 {% endblock %}
 
-{% block page_css_class_class %}reports-archive-detail-page-hip{% endblock %}
+{% block main_area_css_class %}reports-archive-detail-page-mainarea-hip{% endblock main_area_css_class %}
 
 {% block before_staticpage_content %}
   {% include 'includes/breadcrumb.html' %}

--- a/apps/reports/templates/reports/data_report_detail_page.html
+++ b/apps/reports/templates/reports/data_report_detail_page.html
@@ -4,7 +4,7 @@
   {% include 'includes/sidebar.html' %}
 {% endblock %}
 
-{% block page_css_class_class %}reports-detail-page-hip{% endblock %}
+{% block main_area_css_class %}reports-detail-page-mainarea-hip{% endblock main_area_css_class %}
 
 {% block before_staticpage_content %}
   {% include 'includes/breadcrumb.html' %}

--- a/hip/static/styles/pages/data_report_archive_detail_page.scss
+++ b/hip/static/styles/pages/data_report_archive_detail_page.scss
@@ -1,6 +1,6 @@
 @import "../mixins";
 
-.reports-archive-detail-page-hip {
+.reports-archive-detail-page-mainarea-hip {
   @include headers;
   @include paragraphs;
 }

--- a/hip/static/styles/pages/data_report_detail_page.scss
+++ b/hip/static/styles/pages/data_report_detail_page.scss
@@ -1,6 +1,6 @@
 @import "../mixins";
 
-.reports-detail-page-hip {
+.reports-detail-page-mainarea-hip {
   @include headers;
   @include paragraphs;
 }


### PR DESCRIPTION

This pull request:
 - moves the 'before_staticpage_content' block to within the main column of the `StaticPage`
 - moves the CSS class for the report detail and report archive detail pages to be on the main column of the template, rather than a parent of the columns. This way, the styles are only applied to the main column, and not the right nav.