### PR TITLE
[HP-138] Format External Report Dates

### DIFF
--- a/apps/reports/models.py
+++ b/apps/reports/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.db import models
 
 from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel, StreamFieldPanel
@@ -73,8 +75,11 @@ class DataReportListPage(HipBasePage):
         ]
         external_reports = []
         for report in self.external_reports.raw_data:
-            report_data = report["value"]
+            report_data = report["value"].copy()
             report_data["external"] = True
+            report_data["last_updated"] = datetime.strptime(
+                report["value"]["last_updated"], "%Y-%m-%d"
+            ).date()
             external_reports.append(report_data)
         reports = internal_reports + external_reports
         reports.sort(key=lambda r: r["title"].lower())

--- a/apps/reports/templates/reports/data_report_list_page.html
+++ b/apps/reports/templates/reports/data_report_list_page.html
@@ -33,7 +33,7 @@
             </td>
             <td class="is-vcentered">
               <a class="is-inline-block py-4 pl-4 pr-2 full-width-hip is-black-hip" href="{{ report.url }}">
-                {{ report.last_updated }}
+                {{ report.last_updated|date:"M d, Y" }}
               </a>
             </td>
             <td class="py-4 pl-4 pr-2 is-vcentered">

--- a/apps/reports/tests/test_models.py
+++ b/apps/reports/tests/test_models.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from apps.disease_control.tests.factories import DiseaseAndConditionDetailPageFactory
 
 from .factories import (
@@ -101,8 +103,16 @@ def test_datareportslistpage_context_only_external_reports(db, rf):
 
     context = reports_list_page.get_context(rf.get("/someurl/"))
 
+    expected_result_hep_a = external_report_hep_a.copy()
+    expected_result_hep_a["last_updated"] = date(
+        year=2020, month=1, day=1
+    )  # format date to be the expected type
+    expected_result_hiv = external_report_hiv.copy()
+    expected_result_hiv["last_updated"] = date(
+        year=2021, month=1, day=1
+    )  # format date to be the expected type
     # The results should be data for the external reports alphabetical order.
-    assert [external_report_hep_a, external_report_hiv] == context["reports"]
+    assert [expected_result_hep_a, expected_result_hiv] == context["reports"]
 
 
 def test_datareportslistpage_context_internal_and_external_reports(db, rf):
@@ -137,6 +147,10 @@ def test_datareportslistpage_context_internal_and_external_reports(db, rf):
     context = reports_list_page.get_context(rf.get("/someurl/"))
 
     # The results should be data for the internal and external reports in alphabetical order.
+    expected_result_external_report_hiv = external_report_hiv.copy()
+    expected_result_external_report_hiv["last_updated"] = date(
+        year=2021, month=1, day=1
+    )  # format date to be the expected type
     expected_results = [
         {
             "title": report_annual.title,
@@ -146,7 +160,7 @@ def test_datareportslistpage_context_internal_and_external_reports(db, rf):
             "associated_disease": None,
             "external": False,
         },
-        external_report_hiv,
+        expected_result_external_report_hiv,
         {
             "title": report_tuberculosis.title,
             "url": report_tuberculosis.url,


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-138

This pull request changes the external reports' `last_updated` value sent to the template to be a date, to match internal reports' `last_updated` value.

