### PR TITLE
Allow PCWMSAHomePage To Have Children

### DIFF
--- a/apps/auth_content/models.py
+++ b/apps/auth_content/models.py
@@ -115,6 +115,7 @@ class ClosedPODChildPage(StaticPage):
 class PCWMSAHomePage(StaticPage):
     max_count = 1
     parent_page_types = ["hip.HomePage"]
+    subpage_types = ["hip.StaticPage", "hip.ListPage"]
 
     subtitle = models.CharField(
         max_length=255,


### PR DESCRIPTION
This pull request explicitly defines `PCWMSAHomePage`' children to be either `StaticPage`s or `ListPage`s.