### PR TITLE
HP-145: Don't try to validate file if it hasn't changed and turn off error emails

### DIFF
--- a/apps/hip/forms.py
+++ b/apps/hip/forms.py
@@ -11,7 +11,9 @@ class ValidateFileTypeForm(BaseDocumentForm):
 
     def clean_file(self):
         uploaded_file = self.cleaned_data["file"]
-        if uploaded_file:
+        if uploaded_file and "file" in self.changed_data:
+            # Only validate the file type if a file made it through previous validation
+            # AND if it has changed
             content_type = uploaded_file.content_type
             extension = content_type.split("/")[1]
             if extension.lower() not in settings.WAGTAILDOCS_EXTENSIONS:

--- a/apps/hip/tests/factories.py
+++ b/apps/hip/tests/factories.py
@@ -2,6 +2,7 @@ from django.utils.timezone import now
 
 import factory
 import wagtail_factories
+from wagtail.documents import get_document_model
 
 from ..models import HomePage, ListPage, StaticPage
 
@@ -65,3 +66,11 @@ class ListPageFactory(wagtail_factories.PageFactory):
 
     class Meta:
         model = ListPage
+
+
+class DocumentFactory(factory.django.DjangoModelFactory):
+    title = "A document title"
+    file = factory.django.FileField(filename="fake.pdf")
+
+    class Meta:
+        model = get_document_model()

--- a/apps/hip/tests/test_forms.py
+++ b/apps/hip/tests/test_forms.py
@@ -1,0 +1,86 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from wagtail.documents import get_document_model
+from wagtail.documents.forms import get_document_form
+
+from apps.hip.tests.factories import DocumentFactory
+
+
+Document = get_document_model()
+DocumentForm = get_document_form(Document)
+
+
+def test_file_is_required(db):
+    data = {
+        "title": "foo",
+    }
+    form = DocumentForm(data=data, files={})
+    assert not form.is_valid()
+    assert "file" in form.errors
+    assert form.errors["file"] == ["This field is required."]
+
+
+def test_pdf_success(db):
+    f = SimpleUploadedFile("fake.pdf", b"fake data", content_type="application/pdf")
+    data = {
+        "title": "foo",
+    }
+    form = DocumentForm(data=data, files={"file": f})
+    assert form.is_valid()
+
+
+def test_jpeg_success(db):
+    f = SimpleUploadedFile("fake.jpeg", b"fake data", content_type="image/jpeg")
+    data = {
+        "title": "foo",
+    }
+    form = DocumentForm(data=data, files={"file": f})
+    assert form.is_valid()
+
+
+def test_jpg_success(db):
+    f = SimpleUploadedFile("fake.jpg", b"fake data", content_type="image/jpeg")
+    data = {
+        "title": "foo",
+    }
+    form = DocumentForm(data=data, files={"file": f})
+    assert form.is_valid()
+
+
+def test_png_success(db):
+    f = SimpleUploadedFile("fake.png", b"fake data", content_type="image/png")
+    data = {
+        "title": "foo",
+    }
+    form = DocumentForm(data=data, files={"file": f})
+    assert form.is_valid()
+
+
+def test_gif_failure(db):
+    f = SimpleUploadedFile("fake.gif", b"fake data", content_type="image/gif")
+    data = {
+        "title": "foo",
+    }
+    form = DocumentForm(data=data, files={"file": f})
+    assert not form.is_valid()
+    assert "Only files with these extensions are allowed" in form.errors["file"][0]
+
+
+def test_edit_document_without_changing_file_success(db):
+    document = DocumentFactory()
+    data = {
+        "title": "new title",
+    }
+    form = DocumentForm(instance=document, data=data, files={})
+    assert form.is_valid()
+
+
+def test_edit_document_when_changing_file_fails_if_file_is_wrong_type(db):
+    document = DocumentFactory()
+    f = SimpleUploadedFile("fake.gif", b"fake data", content_type="image/gif")
+    data = {
+        "title": "new title",
+    }
+    form = DocumentForm(instance=document, data=data, files={"file": f})
+    assert not form.is_valid()
+    assert "Only files with these extensions are allowed" in form.errors["file"][0]

--- a/hip/settings/deploy.py
+++ b/hip/settings/deploy.py
@@ -71,9 +71,7 @@ for backend in TEMPLATES:
             ]
 
 ### ADMINS and MANAGERS
-ADMINS = (
-    ("PDPH Health Information Portal Dev Team", "hip-philly-team@caktusgroup.com"),
-)
+ADMINS = []  # we use sentry for this
 
 ### 3rd-party appplications
 


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-145

First commit turns of error emails since we get them through sentry (thought I did this before, but obviously I didn't!)

Second commit changes our Document form to only validate the file if it has changed. If a user is only editing the title, for example, we shouldn't even try to validate the existing file.