### PR TITLE
Allow ListPage To Have Children

### DIFF
--- a/apps/hip/models.py
+++ b/apps/hip/models.py
@@ -304,6 +304,8 @@ class ListSectionBlock(blocks.StructBlock):
 
 
 class ListPage(HipBasePage):
+    subpage_types = ["hip.StaticPage", "hip.ListPage"]
+
     show_breadcrumb = models.BooleanField(
         default=False,
         blank=True,


### PR DESCRIPTION
Similar to #129, this pull request explicitly defines `ListPage`s' children to be either `StaticPage`s or `ListPage`s.