### PR TITLE
[HP-151] Report Pages Alignment: Part I

### DIFF
--- a/apps/reports/templates/reports/data_report_detail_page.html
+++ b/apps/reports/templates/reports/data_report_detail_page.html
@@ -10,7 +10,7 @@
   {% include 'includes/breadcrumb.html' %}
   <h2 class="is-inline-block px-4 pt-0">{{ page.title }}</h2>
   {% if archive %}
-    <a href="{{ archive.url }}">View Previous Years</a>
+    <a class="pl-4" href="{{ archive.url }}">View Previous Years</a>
   {% endif %}
 {% endblock %}
 {% block back_button %}{% endblock back_button %}


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-151

This pull request gives the  'View Previous Years' link a left-padding to match the `<h2>` left-padding, in case the `<h2>` contents are so long that they go onto a second line. A future pull request will attempt to make the space between the left sidebar and the main content consistent across the site.