### PR TITLE
Limit Table Width

### DIFF
--- a/hip/static/styles/_mixins.scss
+++ b/hip/static/styles/_mixins.scss
@@ -70,6 +70,7 @@
   table {
     width: 100%;
     table-layout: fixed;
+    max-width: 80vw;
   }
 }
 


### PR DESCRIPTION
This pull request limits table width to 80vw, so tables can not be bigger than the screen.