### PR TITLE
HP-146

### DIFF
--- a/hip/static/styles/includes/mobile_search_modal.scss
+++ b/hip/static/styles/includes/mobile_search_modal.scss
@@ -13,7 +13,6 @@
   }
 
   .no-results-hip {
-    height: 100rem;
     padding-top: 10rem;
   }
 


### PR DESCRIPTION
This PR removes `height` from `no-results-hip` class.  This will prevent the search modal from being very long when there are no search results.

https://caktus.atlassian.net/browse/HP-146