### PR TITLE
[HP-158] Hide Promote Tab "Show in menus"

### DIFF
--- a/apps/common/models.py
+++ b/apps/common/models.py
@@ -41,9 +41,10 @@ class HipBasePage(Page):
             [
                 FieldPanel("slug"),
                 FieldPanel("seo_title"),
-                FieldPanel("show_in_menus"),
                 # override Page's promote_panels to remove search_description (since we
-                # include it in content_panels)
+                # include it in content_panels). Also, don't show "show_in_menus",
+                # since we don't use that field in this project.
+                # FieldPanel("show_in_menus"),
                 # FieldPanel('search_description'),
             ],
             gettext_lazy("Common page configuration"),

--- a/apps/disease_control/models.py
+++ b/apps/disease_control/models.py
@@ -100,9 +100,6 @@ class DiseaseControlChildStaticPage(DiseaseControlPage):
         StreamFieldPanel("body"),
         FieldPanel("page_type"),
     ]
-    promote_panels = [
-        FieldPanel("slug"),
-    ]
     search_fields = HipBasePage.search_fields + [
         index.SearchField("body"),
         index.SearchField("description"),
@@ -150,7 +147,6 @@ class DiseaseControlChildListPage(DiseaseControlPage):
         FieldPanel("description"),
         FieldPanel("page_type"),
     ]
-    promote_panels = [FieldPanel("slug")]
     search_fields = HipBasePage.search_fields + [
         index.SearchField("description"),
         index.SearchField("list_section"),

--- a/apps/hip/models.py
+++ b/apps/hip/models.py
@@ -276,9 +276,6 @@ class StaticPage(HipBasePage):
         FieldPanel("show_right_nav"),
         StreamFieldPanel("body"),
     ]
-    promote_panels = [
-        FieldPanel("slug"),
-    ]
     search_fields = HipBasePage.search_fields + [
         index.SearchField("body"),
     ]
@@ -352,7 +349,6 @@ class ListPage(HipBasePage):
         FieldPanel("show_right_nav"),
         StreamFieldPanel("list_section"),
     ]
-    promote_panels = [FieldPanel("slug")]
     search_fields = HipBasePage.search_fields + [
         index.SearchField("list_section"),
     ]


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-158

This pull request:
 - hides the "Show in menus" field from all pages that inherit from `HipBasePage`
 - makes `StaticPage`, `ListPage`, `DiseaseControlChildStaticPage`, and `DiseaseControlChildListPage` also inherit the promote tab fields from `HipBasePage`