### PR TITLE
Define Children Of DiseaseControlChildStaticPage And DiseaseControlChildListPage

### DIFF
--- a/apps/disease_control/models.py
+++ b/apps/disease_control/models.py
@@ -65,6 +65,8 @@ class DiseaseControlPage(HipBasePage):
 class DiseaseControlChildStaticPage(DiseaseControlPage):
     """A Page that inherits from DiseaseControlPage, and copies fields from StaticPage."""
 
+    subpage_types = ["hip.StaticPage", "hip.ListPage"]
+
     show_left_nav = models.BooleanField(
         default=True,
         blank=True,
@@ -123,6 +125,8 @@ class DiseaseControlChildStaticPage(DiseaseControlPage):
 
 class DiseaseControlChildListPage(DiseaseControlPage):
     """A Page that inherits from DiseaseControlPage, and copies fields from ListPage."""
+
+    subpage_types = ["hip.StaticPage", "hip.ListPage"]
 
     show_breadcrumb = models.BooleanField(
         default=False,


### PR DESCRIPTION
This pull request defines children of `DiseaseControlChildListPage`s and `DiseaseControlChildListPage`s to be `StaticPage`s or `ListPage`s.
