### PR TITLE
Superusers Pass closedpod_user_check

### DIFF
--- a/apps/common/tests/test_utils.py
+++ b/apps/common/tests/test_utils.py
@@ -340,3 +340,19 @@ def test_closedpod_user_check_multiple_groups(db):
     user.groups.add(Group.objects.get(name="Closed POD"))
     user.groups.add(Group.objects.get(name="Big Cities"))
     assert closedpod_user_check(user) is True
+
+
+def test_closedpod_user_check_no_groups_admin_staff(db):
+    """A staff user who is not in any Groups is not Closed POD user."""
+    user = UserFactory()
+    user.is_staff = True
+    user.save()
+    assert closedpod_user_check(user) is False
+
+
+def test_closedpod_user_check_no_groups_superuser(db):
+    """A superuser who is not in any Groups is a Closed POD user."""
+    user = UserFactory()
+    user.is_superuser = True
+    user.save()
+    assert closedpod_user_check(user) is True

--- a/apps/common/utils.py
+++ b/apps/common/utils.py
@@ -66,4 +66,6 @@ def get_all_pages_visible_to_request(request):
 
 def closedpod_user_check(user):
     """A check to determine if a user is in the ClosedPOD Group."""
+    if user.is_superuser:
+        return True
     return not user.is_anonymous and user.groups.filter(name="Closed POD").exists()


### PR DESCRIPTION
This pull request gives superusers permission to the Closed POD contact information page, regardless of whether they are in the "Closed POD" `Group` or not, by making them pass the `closedpod_user_check`.
