### PR TITLE
Upgrade Wagtail

### DIFF
--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -127,7 +127,7 @@ urllib3==1.26.4
     # via
     #   botocore
     #   requests
-wagtail==2.12.1
+wagtail==2.12.4
     # via
     #   -r requirements/base/base.in
     #   wagtailfontawesome

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -502,7 +502,7 @@ virtualenv==20.4.2
     # via pre-commit
 wagtail-factories==2.0.1
     # via -r requirements/dev/dev.in
-wagtail==2.12.1
+wagtail==2.12.4
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail-factories


### PR DESCRIPTION
This pull request upgrades wagtial to its [newest bugfix version](https://docs.wagtail.io/en/stable/releases/2.12.4.html).