### PR TITLE
[HP-169] Footer Links

### DIFF
--- a/apps/common/context_processors.py
+++ b/apps/common/context_processors.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 
+from wagtail.documents import get_document_model
+
 from .utils import (
     get_bigcities_home_page_url,
     get_closedpod_home_page_url,
@@ -86,3 +88,10 @@ def authenticated_home_pages(request):
             )
 
         return {"authenticated_home_pages": auth_pages}
+
+
+def right_to_know_pdf_url(request):
+    """Return the URL for Document named "Right_to_Know.pdf"."""
+    document = get_document_model().objects.filter(title__iexact="right_to_know.pdf")
+    url = document.first().url if document.exists() else ""
+    return {"right_to_know_pdf_url": url}

--- a/apps/hip/templates/includes/footer.html
+++ b/apps/hip/templates/includes/footer.html
@@ -3,9 +3,9 @@
     <p class="pt-5">Copyright 2021 by The City of Philadelphia. All Rights Reserved.</p>
   </div>
   <div class="footer-section-black-hip is-flex is-justify-content-space-around is-align-items-center">
-    <a href="#to-terms-of-use" class="is-block btn-footer">Terms of Use</a>
-    <a href="#to-pdf" class="is-block btn-footer">Right to Know (pdf)</a> 
-    <a href="#privacy-policy" class="is-block btn-footer">Privacy Policy</a> 
-    <a href="#accessibility" class="is-block btn-footer">Accessibility</a> 
+    <a href="/terms-of-use/" class="is-block btn-footer">Terms of Use</a>
+    <a href="{{ right_to_know_pdf_url }}" class="is-block btn-footer">Right to Know (pdf)</a>
+    <a href="/privacy-policy/" class="is-block btn-footer">Privacy Policy</a>
+    <a href="/accessibility/" class="is-block btn-footer">Accessibility</a>
   </div>
 </footer>

--- a/hip/settings/base.py
+++ b/hip/settings/base.py
@@ -105,6 +105,7 @@ TEMPLATES = [
                 "apps.common.context_processors.home_page_url",
                 "apps.common.context_processors.previous_url",
                 "apps.common.context_processors.authenticated_home_pages",
+                "apps.common.context_processors.right_to_know_pdf_url",
             ],
         },
     },


### PR DESCRIPTION
https://caktus.atlassian.net/browse/HP-169

This pull request makes the links in the footer functional by:
 - setting footer links to URLs
 - setting the PDF URL to the value returned by a new context processor, `right_to_know_pdf_url`

Note: these links assume that the appropriate pages have been created in Wagtail.

From a user perspective, it would have been better to give Wagtail users the ability to set the footer URLs, but we're running out of hours, so they are hard-coded for now. Perhaps in the future these links can become editable in Wagtail.