### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.8.9'
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8.9'
+          python-version: '3.8.9'  # Specify bugfix version to avoid regression in 3.8.10
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - run: npm run build-test
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.8.9'
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - run: npm run build-test
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8.9'
+          python-version: '3.8.9'  # Specify bugfix version to avoid regression in 3.8.10
       - name: Cache pip
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This pull request specifies 3.8.9 as our version of Python in our GitHub actions files, to avoid the regression in the 3.8.10 release (https://bugs.python.org/issue44061).