### PR TITLE
DIS-1688 - Add google analytics 

### DIFF
--- a/hip/templates/base.html
+++ b/hip/templates/base.html
@@ -4,6 +4,16 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
   <head>
+    <!-- Google Tag Manager [phila.gov]  -->
+      <script>
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-MC6CR2');
+      </script>
+    <!-- End Google Tag Manager [phila.gov] -->
+
     <meta charset="utf-8" />
     <title>
       {% block title %}
@@ -42,6 +52,13 @@
   </head>
 
   <body>
+    <!-- Google Tag Manager no script [phila.gov] -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MC6CR2"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager no script [phila.gov] -->
+
     {% wagtailuserbar 'bottom-left' %}
     {% include 'includes/header.html' %}
     <div class="columns is-desktop">


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1688

Please note (here)[https://standards.phila.gov/docs/development/analytics.html#analytics-tracking-for-webpages] bullet point 3.

This PR:
- updates `base.html` adding the google analytics script and iframe object. 
- Google Analytics should be present on each page.
- Analytics should work on `hip-staging.phila.gov`, but not `hip.caktus-built.com`. 