### PR TITLE
[DIS-1678] Restrict SSO Users From Logging In With Username & Password

### DIFF
--- a/apps/common/utils.py
+++ b/apps/common/utils.py
@@ -69,3 +69,10 @@ def closedpod_user_check(user):
     if user.is_superuser:
         return True
     return not user.is_anonymous and user.groups.filter(name="Closed POD").exists()
+
+
+def is_sso_user(user):
+    """A user is an SSO user if the user has a django-social-auth object, or a phila.gov email address."""
+    if user.social_auth.exists() or user.email.endswith("phila.gov"):
+        return True
+    return False

--- a/apps/hip/forms.py
+++ b/apps/hip/forms.py
@@ -1,7 +1,11 @@
 from django import forms
 from django.conf import settings
+from django.contrib.auth.forms import AuthenticationForm
+from django.core.exceptions import ValidationError
 
 from wagtail.documents.forms import BaseDocumentForm
+
+from apps.common.utils import is_sso_user
 
 from .utils import scan_pdf_for_malicious_content
 
@@ -31,3 +35,15 @@ class ValidateFileTypeForm(BaseDocumentForm):
                 except Exception as error:
                     raise forms.ValidationError(error)
             return uploaded_file
+
+
+class HIPAuthenticationForm(AuthenticationForm):
+    def confirm_login_allowed(self, user):
+        """SSO users are not allowed to login using the HIPAuthenticationForm."""
+        # Run the AuthenticationForm's confirmation checks.
+        super().confirm_login_allowed(user)
+        # Raise an error if the user is an SSO user.
+        if is_sso_user(user):
+            raise ValidationError(
+                "Users with a Single Sign On (SSO) account must log in via SSO.",
+            )

--- a/apps/hip/templates/registration/login.html
+++ b/apps/hip/templates/registration/login.html
@@ -10,15 +10,24 @@
     <h2 class="pb-5">Response Partner Log In</h2>
 
     {% if form.errors %}
-      <p class="message is-danger p-4 mb-4">Your username and password didn't match. Please try again.</p>
+      {% for error in form.non_field_errors %}
+        <p class="message is-danger p-4 mb-4">{{ error }}</p>
+      {% endfor %}
+
     {% endif %}
 
     <form class="login-form-hip" method="post" action="{% url 'login' %}">
       {% csrf_token %}
 
       <label class="label pb-2" for="id_username">Username:</label>
+      {% if form.errors.username %}
+        {{ form.errors.username }}
+      {% endif %}
       <input class="input is-normal mb-4"type="text" name="username" autofocus="" autocapitalize="none" autocomplete="username" required="" id="id_username">
       <label class="label pb-2" for="id_password">Password:</label>
+      {% if form.errors.password %}
+        {{ form.errors.password }}
+      {% endif %}
       <input class="input is-normal mb-4" type="password" name="password" autocomplete="current-password" required="" id="id_password">
       <div class="mb-4">
         <input type="checkbox" name="remember_me" id="id_remember_me">

--- a/apps/hip/tests/test_views.py
+++ b/apps/hip/tests/test_views.py
@@ -10,6 +10,8 @@ from wagtail.documents import get_document_model
 
 from apps.users.tests.factories import GroupFactory, UserFactory
 
+from ..forms import HIPAuthenticationForm
+
 
 TESTDATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
 
@@ -87,6 +89,8 @@ def test_hip_login_view_get_unauthenticated(db, client):
     response = client.get(reverse("login"))
     assert 200 == response.status_code
     assert ["registration/login.html"] == response.template_name
+    # The form used is the HIPAuthenticationForm.
+    assert isinstance(response.context_data["form"], HIPAuthenticationForm) is True
 
 
 def test_hip_login_view_get_authenticated(db, client):

--- a/apps/hip/views.py
+++ b/apps/hip/views.py
@@ -16,6 +16,8 @@ from apps.common.utils import (
     get_pcwmsa_home_page_url,
 )
 
+from .forms import HIPAuthenticationForm
+
 
 def handler404(request, *args, **argv):
     response = render(request, "404.html", {})
@@ -30,6 +32,8 @@ def handler500(request, *args, **argv):
 
 
 class HIPLoginView(LoginView):
+    authentication_form = HIPAuthenticationForm
+
     def get(self, request, *args, **kwargs):
         """GETting the HIPLoginView redirects authenticated users to the auth_view_router."""
         if request.user.is_authenticated:


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1678

This pull request restricts Single Sign On users from logging in with a username & password by:
 - adding an `is_sso_user()` utility function that determines if a user is an SSO user
 - adding an `HIPAuthenticationForm`, which requires users to be non-SSO users when validating their data
 - using the `HIPAuthenticationForm` on the `HIPLoginView`
 - showing errors for each of the fields of the `HIPAuthenticationForm` in the front-end, rather than hard-coding an error message