### PR TITLE
[DIS-1679] Use Regular Login Page For Wagtail and Django Admin

### DIFF
--- a/apps/hip/tests/test_views.py
+++ b/apps/hip/tests/test_views.py
@@ -255,3 +255,67 @@ def test_upload_document_post(db, client):
         # Verify that the HIPDocument was created.
         document = get_document_model().objects.get(title=expected_file_name)
         assert document.collection == Collection.get_first_root_node()
+
+
+@pytest.mark.parametrize("next_url", ["", "next_url"])
+def test_wagtail_login_redirects_to_cms_and_admin_login_get(db, client, next_url):
+    """Attempting to GET the Wagtail login redirects the user to the cms_and_admin_login view."""
+    url = reverse("wagtailadmin_login")
+    if next_url:
+        url += f"?next={next_url}"
+    response = client.get(url)
+    # The user is redirected to the regular login page, and the 'next' parameter
+    # persists to the regular login page.
+    assert 302 == response.status_code
+    assert f"{reverse('login')}?next={next_url}" == response.url
+
+
+@pytest.mark.parametrize("next_url", ["", "next_url"])
+def test_wagtail_login_redirects_to_cms_and_admin_login_post(db, client, next_url):
+    """Attempting to POST to Wagtail login redirects user to cms_and_admin_login view."""
+    user = UserFactory(email="test-user")
+    user.set_password("testpassword1")
+    user.save()
+
+    url = reverse("wagtailadmin_login")
+    if next_url:
+        url += f"?next={next_url}"
+
+    response = client.post(url, {"username": user.email, "password": "testpassword1"})
+
+    # The user is redirected to the regular login page, and the 'next' parameter
+    # persists to the regular login page.
+    assert 302 == response.status_code
+    assert f"{reverse('login')}?next={next_url}" == response.url
+
+
+@pytest.mark.parametrize("next_url", ["", "next_url"])
+def test_djangoadmin_login_redirects_to_cms_and_admin_login_get(db, client, next_url):
+    """Attempting to GET Django admin login redirects user to cms_and_admin_login view."""
+    url = reverse("admin:login")
+    if next_url:
+        url += f"?next={next_url}"
+    response = client.get(url)
+    # The user is redirected to the regular login page, and the 'next' parameter
+    # persists to the regular login page.
+    assert 302 == response.status_code
+    assert f"{reverse('login')}?next={next_url}" == response.url
+
+
+@pytest.mark.parametrize("next_url", ["", "next_url"])
+def test_djangoadmin_login_redirects_to_cms_and_admin_login_post(db, client, next_url):
+    """Attempting to POST to Django admin login redirects user to cms_and_admin_login view."""
+    user = UserFactory(email="test-user")
+    user.set_password("testpassword1")
+    user.save()
+
+    url = reverse("admin:login")
+    if next_url:
+        url += f"?next={next_url}"
+
+    response = client.post(url, {"username": user.email, "password": "testpassword1"})
+
+    # The user is redirected to the regular login page, and the 'next' parameter
+    # persists to the regular login page.
+    assert 302 == response.status_code
+    assert f"{reverse('login')}?next={next_url}" == response.url

--- a/apps/hip/views.py
+++ b/apps/hip/views.py
@@ -102,3 +102,9 @@ class HIPDocumentAddView(AddView):
     def _dispatch(self, request):
         """A private CSRF-protected view, returned from self.dispatch()."""
         return super().dispatch(request)
+
+
+def cms_and_admin_login(request, *args, **kwargs):
+    next_url = request.GET.get("next", "")
+    login_url = f"{reverse('login')}?next={next_url}"
+    return redirect(login_url)

--- a/hip/urls.py
+++ b/hip/urls.py
@@ -32,6 +32,10 @@ urlpatterns = [
         health_alert_views.subscribe,
         name="health_alert_subscriber",
     ),
+    # Send attempts to log in to the Django admin to the cms_and_admin_login view.
+    # Note: this URL pattern must be before the admin.site.urls patterns, so that
+    # we can intercept the request successfully.
+    path("admin/login/", hip_views.cms_and_admin_login),
     path("admin/", admin.site.urls),
 ]
 
@@ -71,6 +75,10 @@ urlpatterns += [
     # HIPDocumentAddView. Note: this view must be before the wagtailadmin_urls,
     # so that we can intercept the request successfully.
     path("cms/documents/multiple/add/", hip_views.HIPDocumentAddView.as_view()),
+    # Send attempts to log in to the Wagtail CMS to the cms_and_admin_login view.
+    # Note: this url pattern must be before the wagtailadmin_urls patterns, so
+    # that we can intercept the request successfully.
+    path("cms/login/", hip_views.cms_and_admin_login),
     path("cms/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("", include(wagtail_urls)),


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1679

This pull request redirects requests for the Wagtail login page and Django admin login page to go to the regular login page. The `next` URL parameter, if present, persists to the regular login page.