### PR TITLE
[DIS-1680] Update Login Page Design

### DIFF
--- a/apps/emergency_response/templates/includes/partner_login_card.html
+++ b/apps/emergency_response/templates/includes/partner_login_card.html
@@ -13,7 +13,7 @@
       <i class="signin-icon-hip"></i>
     </span>
     <span class="button login-btn-hip btn-on-partnercard-hip ml-0">
-      <strong>Partner Log In</strong>
+      <strong>Log In</strong>
     </span>
   </a>
   <p class="response-partner-login__paragraph-hip pb-4">

--- a/apps/hip/templates/includes/header.html
+++ b/apps/hip/templates/includes/header.html
@@ -64,7 +64,7 @@
               <span class="button is-size-7-touch header-icon-hip ml-0">
                 <i class="signin-icon-hip"></i>
               </span>
-              <span class="button is-size-7-touch header-btn-hip ml-0 pr-6">
+              <span class="button is-size-7-touch header-btn-hip ml-0">
                 <strong>Log In</strong>
               </span>
             </a>

--- a/apps/hip/templates/includes/header.html
+++ b/apps/hip/templates/includes/header.html
@@ -65,7 +65,7 @@
                 <i class="signin-icon-hip"></i>
               </span>
               <span class="button is-size-7-touch header-btn-hip ml-0 pr-6">
-                <strong>Partner Log In</strong>
+                <strong>Log In</strong>
               </span>
             </a>
           {% endif %}

--- a/apps/hip/templates/registration/login.html
+++ b/apps/hip/templates/registration/login.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="login-page-hip columns px-5">
-  <div class="column is-half is-offset-one-quarter">
+  <div class="column is-half px-6">
     <h2 class="pb-5">Response Partner Log In</h2>
 
     {% if form.errors %}
@@ -42,7 +42,11 @@
 
     <h3>About this Network</h3>
     <p>Authorization to access these sites must be approved by the Philadelphia Department of Public Health’s Division of Disease Control. Please send an email to <a href="mailto:healthresponse@phila.gov">healthresponse@phila.gov</a> to request information about becoming a response partner.</p>
+  </div>
 
+  <div class="divider-vertical-hip pt-6"></div>
+
+  <div class="column is-half px-6">
     <h2 class="pb-5">City Log In</h2>
 
     <a class="button login-btn-hip full-width-hip mb-4"

--- a/hip/static/styles/common.scss
+++ b/hip/static/styles/common.scss
@@ -140,11 +140,11 @@ body.modal-is-open-hip {
 .divider-vertical-hip {
     display: flex;
     flex-direction: column;
-}
 
-.divider-vertical-hip:before {
-    content: '';
-    flex: 1;
-    background-color: $grey;
-    width: 1px;
+    &:before {
+      content: '';
+      flex: 1;
+      background-color: $grey;
+      width: 1px;
+    }
 }

--- a/hip/static/styles/common.scss
+++ b/hip/static/styles/common.scss
@@ -135,3 +135,16 @@ body.modal-is-open-hip {
 .alert-hip {
   color: $alert;
 }
+
+
+.divider-vertical-hip {
+    display: flex;
+    flex-direction: column;
+}
+
+.divider-vertical-hip:before {
+    content: '';
+    flex: 1;
+    background-color: $grey;
+    width: 1px;
+}

--- a/hip/static/styles/common.scss
+++ b/hip/static/styles/common.scss
@@ -138,13 +138,13 @@ body.modal-is-open-hip {
 
 
 .divider-vertical-hip {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 
-    &:before {
-      content: '';
-      flex: 1;
-      background-color: $grey;
-      width: 1px;
-    }
+  &:before {
+    content: '';
+    flex: 1;
+    background-color: $grey;
+    width: 1px;
+  }
 }

--- a/hip/static/styles/includes/partner_login_card.scss
+++ b/hip/static/styles/includes/partner_login_card.scss
@@ -16,14 +16,6 @@
   @include light-blue-bg;
   border-radius: 0;
 }
-.btn-on-partnercard-hip {
-  @media screen and (min-width:$breakpoint-tablet) and (max-width: $breakpoint-desktop) {
-    max-width: 75%;
-  }
-  @media screen and (min-width:$breakpoint-widescreen) {
-    width: 80%;
-  }
-}
 .login-icon-hip {
   @include black-bg;
   border-radius: 0;


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1680

This pull request:
 - separates the login page vertically by using a divider `<div>` element, so that the username/password login is on the left side, and the SSO login is on the right side
 - updates the header link to say 'Log In', rather than 'Partner Log In'
 - updates the `partner_login_card.html` link to say 'Log In', rather than 'Partner Log In'
 - removes styles for the partner login card, which are no longer needed, since they were previously used to make sure the 'Partner Log In' button was not too wide

