### PR TITLE
[DIS-1695] Temporarily Comment Out SSO User Changes

### DIFF
--- a/apps/hip/forms.py
+++ b/apps/hip/forms.py
@@ -1,13 +1,15 @@
 from django import forms
 from django.conf import settings
 from django.contrib.auth.forms import AuthenticationForm
-from django.core.exceptions import ValidationError
 
 from wagtail.documents.forms import BaseDocumentForm
 
-from apps.common.utils import is_sso_user
-
 from .utils import scan_pdf_for_malicious_content
+
+
+# TODO from DIS-1695: uncomment this section once HIP SSO issues are worked out.
+# from django.core.exceptions import ValidationError
+# from apps.common.utils import is_sso_user
 
 
 class ValidateFileTypeForm(BaseDocumentForm):
@@ -43,7 +45,8 @@ class HIPAuthenticationForm(AuthenticationForm):
         # Run the AuthenticationForm's confirmation checks.
         super().confirm_login_allowed(user)
         # Raise an error if the user is an SSO user.
-        if is_sso_user(user):
-            raise ValidationError(
-                "Users with a Single Sign On (SSO) account must log in via SSO.",
-            )
+        # TODO from DIS-1695: uncomment this section once HIP SSO issues are worked out.
+        # if is_sso_user(user):
+        #     raise ValidationError(
+        #         "Users with a Single Sign On (SSO) account must log in via SSO.",
+        #     )

--- a/apps/hip/tests/test_forms.py
+++ b/apps/hip/tests/test_forms.py
@@ -2,13 +2,16 @@ import os
 
 from django.core.files.uploadedfile import SimpleUploadedFile, TemporaryUploadedFile
 
-import pytest
 from wagtail.documents import get_document_model
 from wagtail.documents.forms import get_document_form
 
-from apps.hip.forms import HIPAuthenticationForm
 from apps.hip.tests.factories import DocumentFactory
-from apps.users.tests.factories import UserFactory
+
+
+# TODO from DIS-1695: uncomment this section once HIP SSO issues are worked out.
+# import pytest
+# from apps.hip.forms import HIPAuthenticationForm
+# from apps.users.tests.factories import UserFactory
 
 
 TESTDATA_DIR = os.path.join(os.path.dirname(__file__), "testdata")
@@ -133,33 +136,34 @@ def test_edit_document_when_changing_file_fails_if_file_is_wrong_type(db):
     assert "Only files with these extensions are allowed" in form.errors["file"][0]
 
 
-@pytest.mark.parametrize(
-    "is_sso_user,expected_validity",
-    [
-        (True, False),
-        (False, True),
-    ],
-)
-def test_hip_authentication_form_sso_user(db, mocker, is_sso_user, expected_validity):
-    """Only non-SSO users' data is valid for the HIPAuthenticationForm."""
-    # Mock the is_sso_user() function.
-    mock_is_sso_user = mocker.patch("apps.hip.forms.is_sso_user")
-    mock_is_sso_user.return_value = is_sso_user
-
-    # Instantiate the HIPAuthenticationForm form.
-    user = UserFactory(password="testpassword1")
-    form = HIPAuthenticationForm(
-        data={"username": user.email, "password": "testpassword1"}
-    )
-
-    # If the user is an SSO user, then the user is not allowed to login.
-    if expected_validity:
-        assert form.is_valid() is True
-    else:
-        assert form.is_valid() is False
-        expected_error = (
-            "Users with a Single Sign On (SSO) account must log in via SSO."
-        )
-        assert [expected_error] == [error for error in form.errors["__all__"]]
-    # The mock_is_sso_user was called.
-    assert mock_is_sso_user.called is True
+# TODO from DIS-1695: uncomment this section once HIP SSO issues are worked out.
+# @pytest.mark.parametrize(
+#     "is_sso_user,expected_validity",
+#     [
+#         (True, False),
+#         (False, True),
+#     ],
+# )
+# def test_hip_authentication_form_sso_user(db, mocker, is_sso_user, expected_validity):
+#     """Only non-SSO users' data is valid for the HIPAuthenticationForm."""
+#     # Mock the is_sso_user() function.
+#     mock_is_sso_user = mocker.patch("apps.hip.forms.is_sso_user")
+#     mock_is_sso_user.return_value = is_sso_user
+#
+#     # Instantiate the HIPAuthenticationForm form.
+#     user = UserFactory(password="testpassword1")
+#     form = HIPAuthenticationForm(
+#         data={"username": user.email, "password": "testpassword1"}
+#     )
+#
+#     # If the user is an SSO user, then the user is not allowed to login.
+#     if expected_validity:
+#         assert form.is_valid() is True
+#     else:
+#         assert form.is_valid() is False
+#         expected_error = (
+#             "Users with a Single Sign On (SSO) account must log in via SSO."
+#         )
+#         assert [expected_error] == [error for error in form.errors["__all__"]]
+#     # The mock_is_sso_user was called.
+#     assert mock_is_sso_user.called is True


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1648

This pull request temporarily comments out the change from #181, which forced phila.gov users to use SSO. The plan is to uncomment this code once SSO permissions issues are sorted out, hopefully early next week.