### PR TITLE
[DIS-1699] Update Partner Login Card Header Text

### DIFF
--- a/apps/emergency_response/templates/includes/partner_login_card.html
+++ b/apps/emergency_response/templates/includes/partner_login_card.html
@@ -1,5 +1,5 @@
 <div class="response-partner-login-hip mt-6 mb-4 ml-4 p-4">
-  <h3>Response Partner Log In</h3>
+  <h3>Log In</h3>
   <div class="response-partner-login__list-hip">
     <div>Log in to access plans for:</div>
     <ul>


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1699

This pull request updates the header on the partner login card to be 'Log In', rather than 'Partner Log In'.