### PR TITLE
WIP: [DIS-1677] New Production Domain

### DIFF
--- a/deploy/host_vars/production.yml
+++ b/deploy/host_vars/production.yml
@@ -1,8 +1,8 @@
 env_name: "production"
 
 k8s_domain_names:
+  - hip.phila.gov
   - hip-prod.caktus-built.com
-  # - hip.phila.gov
 
 # delete this entry once we go live on hip.phila.gov
 k8s_container_htpasswd: "hip:{SHA}Y2fEjdGT1W6nsLqtJbGUVeUp9e4="


### PR DESCRIPTION
**Warning: do not merge until HIP Philly folks have pointed their DNS record for phila.gov at our load balancer.**

https://caktus.atlassian.net/browse/DIS-1677

This pull request uncomments the production domain in the production environment variables.
