### PR TITLE
[DIS-1701] Part III: Add 'next' URL Parameter For Forms

### DIFF
--- a/apps/common/tests/test_utils.py
+++ b/apps/common/tests/test_utils.py
@@ -21,6 +21,7 @@ from ..utils import (
     get_closedpod_home_page_url,
     get_emergency_communications_page_url,
     get_home_page_url,
+    get_next_url_from_request,
     get_pcwmsa_home_page_url,
     is_sso_user,
 )
@@ -450,3 +451,26 @@ def test_is_sso_user(
 
     # Verify the value of the is_sso_user() utility function for the user.
     assert is_sso_user(user) is expected_result
+
+
+@pytest.mark.parametrize(
+    "next_url,http_referrer_header,expected_url",
+    [
+        (None, None, None),
+        ("", "", None),
+        ("/the_next_url/", "", "/the_next_url/"),
+        ("", "/the_http_referer_header/", "/the_http_referer_header/"),
+        ("/the_next_url/", "/the_http_referer_header/", "/the_next_url/"),
+    ],
+)
+def test_get_next_url_from_request(
+    db, rf, next_url, http_referrer_header, expected_url
+):
+    """Test the get_next_url_from_request() utility function."""
+    request_url = "/test_url/"
+    if next_url is not None:
+        request_url += f"?next={next_url}"
+    request = rf.get(request_url, HTTP_REFERER=http_referrer_header)
+
+    result = get_next_url_from_request(request)
+    assert expected_url == result

--- a/apps/common/utils.py
+++ b/apps/common/utils.py
@@ -78,6 +78,20 @@ def get_all_pages_visible_to_request(request):
     return Page.objects.filter(id__in=pages_for_user.values_list("id", flat=True))
 
 
+def get_next_url_from_request(request):
+    """
+    Get the next URL from the request.
+
+    If the request has a 'next' parameter, then return its value. Otherwise,
+    return the value of the HTTP_REFERER header.
+    """
+    next_parameter = request.GET.get("next", "")
+    if next_parameter:
+        return next_parameter
+    else:
+        return request.META.get("HTTP_REFERER", None) or None
+
+
 def closedpod_user_check(user):
     """A check to determine if a user is in the ClosedPOD Group."""
     if user.is_superuser:

--- a/apps/notifications/templates/notifications/notification_signup.html
+++ b/apps/notifications/templates/notifications/notification_signup.html
@@ -19,7 +19,7 @@
     </div>
     <div class="px-4 columns is-widescreen">
       {# Form Section #}
-      <form class="column is-half-desktop" method="post">
+      <form class="column is-half-desktop" method="post" action="{{ request.path }}?next={{ next }}">
         {% csrf_token %}
         <div>
           {% include 'includes/field_errors.html' with errors=form.non_field_errors %}

--- a/apps/notifications/tests/test_views.py
+++ b/apps/notifications/tests/test_views.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from django.contrib.messages import get_messages
 from django.urls import reverse
 
+import pytest
 from pytest_django.asserts import assertTemplateUsed
 
 from ..forms import (
@@ -22,65 +23,65 @@ def test_get_internal_alerts_signup_page(db, client):
     assert isinstance(response.context["form"], InternalAlertsSubscriberForm)
 
 
-def test_internal_alerts_signup_valid_data_no_previous_referrer(
-    db, client, mocker, internal_alert_data
+@pytest.mark.parametrize(
+    "next_url,http_referrer_header,expected_success_url",
+    [
+        ("", "", "/the_emergency_communications_page/"),
+        ("/next_url/", "", "/next_url/"),
+        ("", "/http_referrer_header/", "/http_referrer_header/"),
+        ("/next_url/", "/http_referrer_header/", "/next_url/"),
+    ],
+)
+def test_internal_alerts_signup_valid_data(
+    db,
+    client,
+    mocker,
+    internal_alert_data,
+    next_url,
+    http_referrer_header,
+    expected_success_url,
 ):
     """
     POSTting valid data redirects the user, and shows a success message.
 
-    If the request has no HTTP_REFERER, then the get_emergency_communications_page_url()
-    utility function is used to determine where the user should be redirected upon
-    POSTing valid data.
+    If the request has a "next" parameter, then the user should be sent to that URL.
+    Otherwise, if the request has an HTTP_REFERER header, then the user should be
+    redirected to it.
+    Otherwise, the get_emergency_communications_page_url() utility function is
+    used to determine where the user should be redirected to.
     """
-    # The request in this test has no HTTP_REFERER header, so we mock the
-    # get_emergency_communications_page() function, since it is used to determine
-    # the URL for a successful POST.
+    # Mock the get_emergency_communications_page() function, since it is sometimes
+    # used to determine the redirect URL for a successful POST.
     mock_get_emergency_communications_page_url = mocker.patch(
         "apps.notifications.views.get_emergency_communications_page_url"
     )
     mock_url = "/the_emergency_communications_page/"
     mock_get_emergency_communications_page_url.return_value = mock_url
 
-    response = client.post(reverse("internal_alerts_signup"), internal_alert_data)
+    url = reverse("internal_alerts_signup")
+    if next_url:
+        url += f"?next={next_url}"
+    if http_referrer_header:
+        response = client.post(
+            url, internal_alert_data, HTTP_REFERER=http_referrer_header
+        )
+    else:
+        response = client.post(url, internal_alert_data)
 
     assert HTTPStatus.FOUND == response.status_code
+    assert expected_success_url == response.url
     messages = get_messages(response.wsgi_request)
     expected_message = (
         "You are now subscribed to alerts from the Philadelphia Department of "
         "Public Health Internal Employee Alert System"
     )
-    assert mock_url == response.url
+    assert expected_success_url == response.url
     assert [str(message) for message in messages] == [expected_message]
-
-
-def test_internal_alerts_signup_valid_data_with_previous_referrer(
-    db, client, internal_alert_data
-):
-    """
-    POSTting valid data redirects the user, and shows a success message.
-
-    If the request has an HTTP_REFERER, then the user is redirected to it upon
-    POSTing valid data.
-    """
-    # The request in this test has an HTTP_REFERER header.
-    http_referrer_header = "/the_last_page_url/"
-
-    response = client.post(
-        reverse("internal_alerts_signup"),
-        internal_alert_data,
-        HTTP_REFERER=http_referrer_header,
-    )
-
-    assert HTTPStatus.FOUND == response.status_code
-    # Since the request in this test has an HTTP_REFERER header, that header should
-    # be used as the URL the user is redirected to.
-    assert http_referrer_header == response.url
-    messages = get_messages(response.wsgi_request)
-    expected_message = (
-        "You are now subscribed to alerts from the Philadelphia Department of "
-        "Public Health Internal Employee Alert System"
-    )
-    assert [str(message) for message in messages] == [expected_message]
+    # If the expected_success_url is neither the next_url nor the http_referrer_header,
+    # then it must be from the mocked get_emergency_communications_page() function,
+    # so verify that the get_emergency_communications_page() function was called.
+    if expected_success_url not in [next_url, http_referrer_header]:
+        assert 1 == mock_get_emergency_communications_page_url.call_count
 
 
 def test_internal_alerts_signup_invalid_data(db, client, internal_alert_data):

--- a/apps/notifications/views.py
+++ b/apps/notifications/views.py
@@ -1,14 +1,18 @@
 from django.contrib import messages
 from django.shortcuts import redirect, render
 
-from apps.common.utils import get_emergency_communications_page_url
-
 from .forms import (
     CodeBlueCodeRedSubscriberForm,
     CommunityResponseSubscriberForm,
     InternalAlertsSubscriberForm,
     OpioidOverdoseSubscriberForm,
     PublicHealthPreparednessSubscriberForm,
+)
+
+
+from apps.common.utils import (  # isort: skip
+    get_emergency_communications_page_url,
+    get_next_url_from_request,
 )
 
 
@@ -32,6 +36,7 @@ def generic_notification_signup(
         subscribe_form = form()
 
     context["close_url"] = close_url
+    context["next"] = success_url
     context["form"] = subscribe_form
     return render(request, template_name, context)
 
@@ -42,11 +47,12 @@ def internal_alerts_signup(request):
         "You are now subscribed to alerts from the Philadelphia Department of "
         "Public Health Internal Employee Alert System"
     )
-    previous_page_url = request.META.get("HTTP_REFERER", None)
-    if previous_page_url:
-        success_url = close_url = previous_page_url
+    next_url = get_next_url_from_request(request)
+    if next_url:
+        success_url = close_url = next_url
     else:
         success_url = close_url = get_emergency_communications_page_url()
+
     return generic_notification_signup(
         request,
         InternalAlertsSubscriberForm,


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1701

Currently, submitting the internal alerts form relies on the request's `HTTP_REFERER` parameter to determine the user's previous URL. This works ok, but in case the user submits the internal alerts form and gets the form back with errors, then the `HTTP_REFERER` header is set to the form's URL, meaning that submitting the form will bring the user back to the form.

This pull request: 
 - adds a `get_next_url_from_request()` utility function for getting the next URL from request parameters
 - uses the `get_next_url_from_request()` function to determine the success URL and close URL for the internal alerts form
 - adds a form `action` with the `next` URL parameter to the `notification_signup.html` template