### PR TITLE
Align Each Table Row In Wagtail At The Top

### DIFF
--- a/hip/static/styles/wagtail_styles.scss
+++ b/hip/static/styles/wagtail_styles.scss
@@ -1,19 +1,27 @@
 .two-column-table__row > .field {
     width: 49%;
     display: inline-block;
+    vertical-align: top;
+    padding-top: 1rem;
 }
 
 .three-column-table__row > .field {
     width: 32%;
     display: inline-block;
+    vertical-align: top;
+    padding-top: 1rem;
 }
 
 .four-column-table__row > .field {
     width: 24%;
     display: inline-block;
+    vertical-align: top;
+    padding-top: 1rem;
 }
 
 .five-column-table__row > .field {
     width: 19%;
     display: inline-block;
+    vertical-align: top;
+    padding-top: 1rem;
 }


### PR DESCRIPTION
In order to make the Wagtail interface a little easier to use, each row of tables are now aligned with each other at the top, so we avoid some table cells being above and others being below, like in the screenshot.
<img width="1034" alt="Screen Shot 2021-06-24 at 8 21 23 AM" src="https://user-images.githubusercontent.com/6025153/123261987-6995c180-d4c5-11eb-8a35-2797f0989a47.png">
