### PR TITLE
[DIS-1669] Send Logs To AWS CloudWatch

### DIFF
--- a/apps/users/apps.py
+++ b/apps/users/apps.py
@@ -3,3 +3,7 @@ from django.apps import AppConfig
 
 class UsersConfig(AppConfig):
     name = "apps.users"
+
+    def ready(self):
+        # Import the signals here, so that they are registered.
+        from apps.users import signals  # noqa

--- a/deploy/deploy-cluster.yml
+++ b/deploy/deploy-cluster.yml
@@ -7,3 +7,22 @@
   gather_facts: false
   roles:
     - role: caktus.k8s-web-cluster
+  tasks:
+    - name: Add AWS for fluent bit helm chart (centralized logging)
+      community.kubernetes.helm:
+        context: "{{ k8s_context|mandatory }}"
+        kubeconfig: "{{ k8s_kubeconfig }}"
+        chart_repo_url: "https://aws.github.io/eks-charts"
+        chart_ref: aws-for-fluent-bit
+        # https://artifacthub.io/packages/helm/aws/aws-for-fluent-bit
+        chart_version: "{{ k8s_aws_fluent_bit_chart_version }}"
+        release_name: aws-for-fluent-bit
+        release_namespace: kube-system
+        release_values:
+          firehose:
+            enabled: false
+          kinesis:
+            enabled: false
+          elasticsearch:
+            enabled: false
+        wait: yes

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -75,6 +75,7 @@ k8s_ingress_nginx_chart_version: "3.29.0"
 k8s_cert_manager_chart_version: "v1.3.0"
 k8s_letsencrypt_email: admin@caktusgroup.com
 k8s_iam_users: [noop]  # https://github.com/caktus/ansible-role-k8s-web-cluster/issues/17
+k8s_aws_fluent_bit_chart_version: "0.1.11"  # https://artifacthub.io/packages/helm/aws/aws-for-fluent-bit
 
 # ----------------------------------------------------------------------------
 # caktus.django-k8s: Shared configuration variables for staging and production

--- a/deploy/stack/eks-no-nat.yml
+++ b/deploy/stack/eks-no-nat.yml
@@ -1256,6 +1256,7 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
         - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
       Path: /
       Policies:
         - PolicyDocument:
@@ -2033,4 +2034,3 @@ Resources:
             - - !Ref 'AWS::StackName'
               - vpc
     Type: AWS::EC2::VPC
-


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1669

This pull request:
 - updates the `apps.users.apps.UsersConfig` class to have a `ready()` method, which imports all of the signals in the `users` app. This is a change that we should have made when upgrading to Django3.2, but it looks like no one noticed that the signals stopped working, since we weren't sending the logs anywhere.
 - adds a task to install the "AWS for Fluent Bit" helm chart for the cluster, based on Colin's recommendation in our Slack channel. This task was run with `inv deploy.playbook deploy-cluster.yml`  
 
 The Django logs are now being sent to AWS CloudWatch, and can be seen here: https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:logs-insights .