### PR TITLE
[DIS-1723] Make Headers Match Emergency Response Header

### DIFF
--- a/apps/disease_control/templates/disease_control/disease_and_condition_list_page.html
+++ b/apps/disease_control/templates/disease_control/disease_and_condition_list_page.html
@@ -6,8 +6,8 @@
   {% include 'includes/breadcrumb.html' %}
 {% endif %}
 <div>
-  <div class="disease-control-index-page-hip px-4">
-    <h2><strong>{{ page.title }}</strong></h2>
+  <div class="disease-condition-list-page-hip px-4">
+    <h2>{{ page.title }}</h2>
     <div>
       {% for disease in ordered_diseases %}
         {% include 'includes/disease_control_card.html' with page=disease %}

--- a/apps/disease_control/templates/disease_control/disease_control_list_page.html
+++ b/apps/disease_control/templates/disease_control/disease_control_list_page.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="columns is-desktop">
-  <div class="disease-control-index-page-hip px-4">
+<div class="disease-control-index-page-hip columns is-desktop px-4">
+  <div class="disease-control-index-page-maincolumn-hip column is-three-fourths-desktop is-full-mobile">
     <h2>{{ page.title }}</h2>
     {% if topic_pages.exists %}
       <div class="nav-heading-hip" id="section-{{'Topic-specific Guidance'|slugify}}"></div>

--- a/apps/health_alerts/templates/health_alerts/health_alert_list_page.html
+++ b/apps/health_alerts/templates/health_alerts/health_alert_list_page.html
@@ -2,51 +2,53 @@
 {% load wagtailcore_tags %}
 
 {% block content %}
-  <div class="health-alert-page">
-    <div class="columns">
-      <div class="column">
-        <div class="level">
-          {# Title is on the left #}
-          <div class="level-left">
-            <div class="level-item">
-              <p class="title">
-                {{ page.title }}
-              </p>
+  <div class="health-alert-page columns is-desktop px-4">
+    <div class="column is-three-fourths-desktop is-full-mobile">
+      <div class="columns">
+        <div class="column">
+          <div class="level">
+            {# Title is on the left #}
+            <div class="level-left">
+              <div class="level-item">
+                <h2>{{ page.title }}</h2>
+              </div>
+            </div>
+
+            {# Sign up button is on the right #}
+            <div class="level-right">
+              <div class="level-item">
+                <a href="{% url 'health_alert_subscriber' %}" class="is-block">
+                  <span class="button is-size-7-mobile header-icon-hip">
+                    <i class="email-icon-hip"></i>
+                  </span>
+                  <span class="button is-size-7-mobile header-btn-hip">
+                    <strong>Sign Up For Alerts</strong>
+                  </span>
+                </a>
+              </div>
             </div>
           </div>
 
-          {# Sign up button is on the right #}
-          <div class="level-right">
-            <div class="level-item">
-              <a href="{% url 'health_alert_subscriber' %}" class="is-block">
-                <span class="button is-size-7-mobile header-icon-hip">
-                  <i class="email-icon-hip"></i>
-                </span>
-                <span class="button is-size-7-mobile header-btn-hip">
-                  <strong>Sign Up For Alerts</strong>
-                </span>
-              </a>
-            </div>
-          </div>
-        </div>
-
-        {# Filter widget #}
-        <div class="filter-widget-hip columns m-0">
-          <div class="column">
-            <div class="select">
-              <select class="select-condition">
-                <option value="All">Filter by disease/condition</option>
-                {% for condition in conditions %}
-                  <option value="{{ condition.slug }}">{{ condition }}</option>
-                {% endfor %}
-              </select>
+          {# Filter widget #}
+          <div class="filter-widget-hip columns m-0">
+            <div class="column">
+              <div class="select">
+                <select class="select-condition">
+                  <option value="All">Filter by disease/condition</option>
+                  {% for condition in conditions %}
+                    <option value="{{ condition.slug }}">{{ condition }}</option>
+                  {% endfor %}
+                </select>
+              </div>
             </div>
           </div>
         </div>
       </div>
-      <div class="column is-one-quarter"></div>
     </div>
-    <div class="columns">
+    <div class="column is-one-quarter"></div>
+
+    </div>
+    <div class="columns px-4">
       <div class="column">
         {# Main content table of Health Alerts #}
         <table class="table alert-table-hip">

--- a/apps/health_alerts/templates/health_alerts/health_alert_list_page.html
+++ b/apps/health_alerts/templates/health_alerts/health_alert_list_page.html
@@ -2,51 +2,51 @@
 {% load wagtailcore_tags %}
 
 {% block content %}
-  <div class="health-alert-page columns is-desktop px-4">
-    <div class="column is-three-fourths-desktop is-full-mobile">
-      <div class="columns">
-        <div class="column">
-          <div class="level">
-            {# Title is on the left #}
-            <div class="level-left">
-              <div class="level-item">
-                <h2>{{ page.title }}</h2>
+  <div class="health-alert-page">
+    <div class="columns is-desktop px-4">
+      <div class="column is-three-fourths-desktop is-full-mobile">
+        <div class="columns">
+          <div class="column">
+            <div class="level">
+              {# Title is on the left #}
+              <div class="level-left">
+                <div class="level-item">
+                  <h2>{{ page.title }}</h2>
+                </div>
+              </div>
+
+              {# Sign up button is on the right #}
+              <div class="level-right">
+                <div class="level-item">
+                  <a href="{% url 'health_alert_subscriber' %}" class="is-block">
+                    <span class="button is-size-7-mobile header-icon-hip">
+                      <i class="email-icon-hip"></i>
+                    </span>
+                    <span class="button is-size-7-mobile header-btn-hip">
+                      <strong>Sign Up For Alerts</strong>
+                    </span>
+                  </a>
+                </div>
               </div>
             </div>
 
-            {# Sign up button is on the right #}
-            <div class="level-right">
-              <div class="level-item">
-                <a href="{% url 'health_alert_subscriber' %}" class="is-block">
-                  <span class="button is-size-7-mobile header-icon-hip">
-                    <i class="email-icon-hip"></i>
-                  </span>
-                  <span class="button is-size-7-mobile header-btn-hip">
-                    <strong>Sign Up For Alerts</strong>
-                  </span>
-                </a>
-              </div>
-            </div>
-          </div>
-
-          {# Filter widget #}
-          <div class="filter-widget-hip columns m-0">
-            <div class="column">
-              <div class="select">
-                <select class="select-condition">
-                  <option value="All">Filter by disease/condition</option>
-                  {% for condition in conditions %}
-                    <option value="{{ condition.slug }}">{{ condition }}</option>
-                  {% endfor %}
-                </select>
+            {# Filter widget #}
+            <div class="filter-widget-hip columns m-0">
+              <div class="column">
+                <div class="select">
+                  <select class="select-condition">
+                    <option value="All">Filter by disease/condition</option>
+                    {% for condition in conditions %}
+                      <option value="{{ condition.slug }}">{{ condition }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div class="column is-one-quarter"></div>
-
+      <div class="column is-one-quarter"></div>
     </div>
     <div class="columns px-4">
       <div class="column">

--- a/apps/hip/templates/hip/static_page.html
+++ b/apps/hip/templates/hip/static_page.html
@@ -31,6 +31,8 @@
           {% endblock back_button %}
         {% endif %}
 
+        {% block staticpage_title %}{% endblock staticpage_title %}
+
         {% if page.action_section %}
           <section class="action-section-hip py-4 pl-4">
             {{ page.action_section|richtext }}

--- a/apps/reports/templates/reports/data_report_detail_page.html
+++ b/apps/reports/templates/reports/data_report_detail_page.html
@@ -6,11 +6,10 @@
 
 {% block main_area_css_class %}reports-detail-page-mainarea-hip{% endblock main_area_css_class %}
 
-{% block before_staticpage_content %}
-  {% include 'includes/breadcrumb.html' %}
+{% block staticpage_title %}
   <h2 class="is-inline-block px-4 pt-0">{{ page.title }}</h2>
   {% if archive %}
     <a class="pl-4" href="{{ archive.url }}">View Previous Years</a>
   {% endif %}
-{% endblock %}
+{% endblock staticpage_title %}
 {% block back_button %}{% endblock back_button %}

--- a/apps/reports/templates/reports/data_report_list_page.html
+++ b/apps/reports/templates/reports/data_report_list_page.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div>
   <div class="reports-list-page-hip px-4">
-    <h2><strong>{{ page.title }}</strong></h2>
+    <h2>{{ page.title }}</h2>
     <h4 class="pb-4">{{ page.description|richtext }}</h4>
 
     <table class="full-width-hip is-black-hip table-grid-pattern-hip external-links-with-domains-hip">

--- a/hip/static/styles/bundle.scss
+++ b/hip/static/styles/bundle.scss
@@ -17,6 +17,7 @@ This file will manage all scss file imports.
 @import "./pages/data_report_archive_list_page";
 @import "./pages/data_report_detail_page";
 @import "./pages/data_report_list_page";
+@import "./pages/disease_and_condition_list_page.scss";
 @import "./pages/disease_control_list_page.scss";
 @import "./pages/disease_and_condition_detail_page.scss";
 @import "./pages/emergency_response.scss";

--- a/hip/static/styles/pages/disease_and_condition_list_page.scss
+++ b/hip/static/styles/pages/disease_and_condition_list_page.scss
@@ -1,0 +1,5 @@
+@import "../mixins";
+
+.disease-condition-list-page-hip {
+  @include headers;
+}

--- a/hip/static/styles/pages/disease_control_list_page.scss
+++ b/hip/static/styles/pages/disease_control_list_page.scss
@@ -1,7 +1,7 @@
 @import "../mixins";
 @import "../colors";
 
-.disease-control-index-page-hip {
+.disease-control-index-page-maincolumn-hip {
   @include headers;
   .disease-control-header {
     // done because styles are not consistent with report a disease page styles.

--- a/hip/static/styles/pages/health_alert_list_page.scss
+++ b/hip/static/styles/pages/health_alert_list_page.scss
@@ -2,12 +2,8 @@
 @import "../colors";
 
 .health-alert-page {
-  margin: 0 3rem;
-  @media screen and (max-width: $breakpoint-widescreen) {
-    margin: 0 1.5rem;
-  }
-
   @include tables;
+  @include headers;
 }
 
 .filter-widget-hip {


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1723

This pull request makes the headers on the following pages match the header on the Emergency Response page:
 - disease control list page (/disease-control/)
 - diseases and conditions list page (/disease-control/diseases-and-conditions/)
 - data reports list page (/data-reports-statistics/)
 - health alerts page (/health-alerts/)

Note: I also removed the ability to have a double breadcrumb on data reports detail pages.