### PR TITLE
[DIS-1727] Fix Document Upload For Small Documents

### DIFF
--- a/hip/settings/base.py
+++ b/hip/settings/base.py
@@ -294,6 +294,10 @@ WAGTAILDOCS_DOCUMENT_FORM_BASE = "apps.hip.forms.ValidateFileTypeForm"
 WAGTAILDOCS_EXTENSIONS = ["pdf", "png", "jpg", "jpeg"]
 WAGTAILDOCS_DOCUMENT_MODEL = "hip.HIPDocument"
 
+# Explicitly set the file upload handler to be django.core.files.uploadhandler.TemporaryFileUploadHandler,
+# so that all uploaded files are written to a temporary file. Writing to a file
+# is required for the ValidateFileTypeForm.clean_file() method to scan PDF files.
+FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.TemporaryFileUploadHandler"]
 
 LOGOUT_REDIRECT_URL = "/"
 


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1727

By default, [small files uploaded through the admin/Wagtail use Django's `django.core.files.uploadhandler.MemoryFileUploadHandler`](https://docs.djangoproject.com/en/3.2/topics/http/file-uploads/#where-uploaded-data-is-stored), and larger files use Django’s `django.core.files.uploadhandler.TemporaryFileUploadHandler`. Since the `MemoryFileUploadHandler` holds the contents of the file in memory, an uploaded file using the `MemoryFileUploadHandler` does not have a `temporary_file_path()` method, which is a problem for our `ValidateFileTypeForm.clean_file()` method, which tries to pass a temporary path to our `scan_pdf_for_malicious_content()` function.
It looks like our scanning ability requires having a file path to a PDF file, so this pull request tries to fix the issue by requiring Django to always use the `TemporaryFileUploadHandler` by setting the `FILE_UPLOAD_HANDLERS` setting to that handler.

Note: a side effect of this change is that all uploaded files will be written to a temporary file (like /tmp/tmpsjdfnskdjf.pdf), and will remain there until the system clears out the temporary files. If there are a lot of uploads in a day, this could use up a lot of space, but I doubt that will happen for this site.