### PR TITLE
[DIS-1726] More Consistent Headers On Site

### DIFF
--- a/apps/auth_content/templates/auth_content/big_cities_home_page.html
+++ b/apps/auth_content/templates/auth_content/big_cities_home_page.html
@@ -7,6 +7,6 @@
 {% block page_css_class %}bigcities-homepage-hip{% endblock page_css_class %}
 
 {% block before_staticpage_content %}
-  <h2 class="is-inline-block px-4 pt-0">{{ page.title }}</h2>
+  <h2 class="is-inline-block px-4">{{ page.title }}</h2>
 {% endblock %}
 {% block back_button %}{% endblock back_button %}

--- a/apps/auth_content/templates/auth_content/closedpod_contact_information.html
+++ b/apps/auth_content/templates/auth_content/closedpod_contact_information.html
@@ -8,8 +8,10 @@
       {% include 'includes/message.html' with messages=messages %}
     </div>
   </div>
-  <section class="columns px-2">
-    <h2 class="is-size-2 column is-5 has-text-centered-mobile">Contact Information</h2>
+  <section class="columns">
+    <div class="is-size-2 column is-5">
+      <h2 class="has-text-centered-mobile">Contact Information</h2>
+    </div>
 
     <div class="column is-7 pt-5">
       <div class="level-item">

--- a/apps/auth_content/templates/auth_content/closedpod_contact_information.html
+++ b/apps/auth_content/templates/auth_content/closedpod_contact_information.html
@@ -3,11 +3,6 @@
 
 {% block content %}
 <div class="closed-pod-homepage-hip px-4">
-  <div class="columns pr-6">
-    <div class="column is-10">
-      {% include 'includes/message.html' with messages=messages %}
-    </div>
-  </div>
   <section class="columns">
     <div class="is-size-2 column is-5">
       <h2 class="has-text-centered-mobile">Contact Information</h2>

--- a/apps/posters/templates/posters/poster_detail_page.html
+++ b/apps/posters/templates/posters/poster_detail_page.html
@@ -7,7 +7,7 @@
 {% endcomment %}
 
 {% block content %}
-  <div class="poster-list-page-hip">
+  <div class="poster-list-page-hip px-4">
     <h2>Poster: {{ page.title }}</h2>
     {% include "includes/poster_card.html" with poster=page %}
   </div>

--- a/apps/posters/templates/posters/poster_list_page.html
+++ b/apps/posters/templates/posters/poster_list_page.html
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="columns">
     <div class="column">
-      <div class="poster-list-page-hip px-4 py-3">
+      <div class="poster-list-page-hip px-4">
         <h2>{{ page.title }}</h2>
 
         {% regroup posters by category as poster_list %}


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1726

Following up on the work in #210, this pull request makes headers on the following pages match the header on the Emergency Response page:
 - posters list page (/posters/)
 - poster detail page (for example: /posters/prevent-the-spread-of-norovirus/)
 - closed POD contact page (/closed-pod/closedpod-contact-information/)
 - big cities homepage (/big-cities-public-health-preparedness/)

As a note, I also removed the double message on the closed POD contact information page.