### PR TITLE
[DIS-1669] Documentation

### DIFF
--- a/docs/hosting-services.md
+++ b/docs/hosting-services.md
@@ -50,7 +50,7 @@ project, certain developers are notified when an error is logged:
    by the filter, then the alarm is triggered, and posts to a Simple Notification Service
    (SNS) topic named "HIP_Errors_CloudWatch_Alarms_Topic"
  - the SNS topic emails the Caktus HIP development team (hip-philly-team@caktusgroup.com)
-   that the ararm has been triggered due to an error on the site.
+   that the alarm has been triggered due to an error on the site.
 
 You may also view error logs in the AWS Console:
  - log in to the AWS Console

--- a/docs/hosting-services.md
+++ b/docs/hosting-services.md
@@ -36,6 +36,57 @@ awslogs get /aws/eks/fluentbit-cloudwatch/logs "fluentbit-kube.var.log.container
 ```
 
 
+## Error Logs
+
+All Kubernetes cluster and application logs are sent to AWS CloudWatch, but it can be
+useful to know when an error is logged. Specifically, as a part of maintaining the
+project, certain developers are notified when an error is logged:
+
+ - a log filter has been set up to catch all logs that contain the string "ERROR". You
+   can find this filter in the AWS Console, in the CloudWatch service, by clicking on "Log
+   groups", choosing the "/aws/eks/fluentbit-cloudwatch/logs" log group, and clicking on the
+   "Metric filters" tab.
+ - a CloudWatch alarm has been set up to watch the error filter. If an error gets caught
+   by the filter, then the alarm is triggered, and posts to a Simple Notification Service
+   (SNS) topic named "HIP_Errors_CloudWatch_Alarms_Topic"
+ - the SNS topic emails the Caktus HIP development team (hip-philly-team@caktusgroup.com)
+   that the ararm has been triggered due to an error on the site.
+
+You may also view error logs in the AWS Console:
+ - log in to the AWS Console
+ - switch to the HIP role (https://signin.aws.amazon.com/switchrole?roleName=CaktusAccountAccessRole-Admins&account=061553509755&displayName=Philly-PDPH)
+ - navigate to the AWS CloudWatch service, and go to the "/aws/eks/fluentbit-cloudwatch/logs" log group
+
+To watch for error logs in the terminal using `awslogs`:
+
+```sh
+awslogs get /aws/eks/fluentbit-cloudwatch/logs -GS --query log --watch | grep "ERROR"
+```
+
+
+### Receiving A Notification Of An Error
+
+The "HIP_Errors_CloudWatch_Alarms_Topic" emails that notify developers that the alarm has been
+triggered are pretty vague, with a subject like "ALARM: "HIP Errors alarm"", and a body
+that begins with something like
+"You are receiving this email because your Amazon CloudWatch Alarm ... has entered the ALARM
+state". When receiving this alarm, it will be helpful to figure out more information about
+the error, such as which environment (staging or production) the error occurred in and
+how serious the error was. To do so,
+ - click on the link in the email, which should take you to the AWS CloudWatch alarm (you
+   will need to log into the AWS Console). Note the time that the alarm was first triggered.
+ - you can then go to the CloudWatch logs and view the logs in the
+   "/aws/eks/fluentbit-cloudwatch/logs" log group. You can click on the logs for a
+   specific container, or search for specific terms, like "ERROR".
+
+Alternately, you can check the errors using the command line. For example, to see all
+logs from the past 3 hours that match "ERROR":
+
+```sh
+awslogs get /aws/eks/fluentbit-cloudwatch/logs -GS --query log --start='3h' | grep ERROR
+```
+
+
 ## Production backup and hosting services configuration
 
 [caktus.k8s-hosting-services](https://github.com/caktus/ansible-role-k8s-hosting-services)

--- a/docs/hosting-services.md
+++ b/docs/hosting-services.md
@@ -54,7 +54,7 @@ project, certain developers are notified when an error is logged:
 
 You may also view error logs in the AWS Console:
  - log in to the AWS Console
- - switch to the HIP role (https://signin.aws.amazon.com/switchrole?roleName=CaktusAccountAccessRole-Admins&account=061553509755&displayName=Philly-PDPH)
+ - switch to the [HIP role](https://signin.aws.amazon.com/switchrole?roleName=CaktusAccountAccessRole-Admins&account=061553509755&displayName=Philly-PDPH)
  - navigate to the AWS CloudWatch service, and go to the "/aws/eks/fluentbit-cloudwatch/logs" log group
 
 To watch for error logs in the terminal using `awslogs`:


### PR DESCRIPTION
https://caktus.atlassian.net/browse/DIS-1669

This pull request adds documentation about how error logs are handled in AWS, including using a CloudWatch alarm, and how to investigate further when notified of an error.