### PR TITLE
Fix Deployment Issue With RabbitMQ

### DIFF
--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -4,9 +4,11 @@
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
   version: v1.1.0
   name: caktus.k8s-web-cluster
+# Note: caktus.django-k8s version 1.4.0 has been released, but deploys fail due to issue:
+# msg: Failed to find exact match for rabbitmq.com/v1beta1.RabbitmqCluster by [kind, name, singularName, shortNames]
 - src: https://github.com/caktus/ansible-role-django-k8s
   name: caktus.django-k8s
-  version: v1.4.0
+  version: v1.3.0
 - src: https://github.com/caktus/ansible-role-k8s-hosting-services
   name: caktus.k8s-hosting-services
   version: v0.3.0


### PR DESCRIPTION
This pull request downgrades the version of `ansible-role-django-k8s` to 1.3.0, so deploys do not fail on a rabbitmq error:
```
failed: [staging] (item={'name': 'rabbitmq.yaml.j2', 'state': 'absent'}) => changed=false 
  ansible_loop_var: item
  item:
    name: rabbitmq.yaml.j2
    state: absent
  msg: Failed to find exact match for rabbitmq.com/v1beta1.RabbitmqCluster by [kind, name, singularName, shortNames]
```