### PR TITLE
Remove caktus-built.com Domain For Staging Site

### DIFF
--- a/deploy/host_vars/staging.yml
+++ b/deploy/host_vars/staging.yml
@@ -2,7 +2,6 @@ env_name: "staging"
 
 k8s_domain_names:
   - hip-staging.phila.gov
-  - hip.caktus-built.com
 
 k8s_auth_api_key: !vault |
   $ANSIBLE_VAULT;1.1;AES256


### PR DESCRIPTION
To prepare for merging #193 and having the site go live, this pull request removes the caktus-built.com domain from the staging site.