### PR TITLE
Upgrade Django To Latest Bugfix Version

### DIFF
--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -33,7 +33,7 @@ diff-match-patch==20200713
     # via django-import-export
 dj-database-url==0.5.0
     # via -r requirements/base/base.in
-django==3.2.5
+django==3.2.11
     # via
     #   -r requirements/base/base.in
     #   django-appconf

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -107,7 +107,7 @@ defusedxml==0.7.1
     #   odfpy
 distlib==0.3.1
     # via virtualenv
-django==3.2.5
+django==3.2.11
     # via
     #   -c requirements/dev/../base/base.txt
     #   django-debug-toolbar


### PR DESCRIPTION
To make sure that HIP isn't affected by the issues from today's Django [security release](https://www.djangoproject.com/weblog/2022/jan/04/security-releases/), this pull request upgrades Django to the latest bugfix version.
As a note, it looks like CVE-2021-45115 and CVE-2021-45116 are not actually issues for HIP, but it shouldn't hurt to be on the latest version.