### PR TITLE
Fix Upgrade NodeJS from version 12 to version 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ static/*
 public/static/
 public/media/
 media/*
-webpack-stats.json
 hip/static/bundles/main.js
 
 # Ansible

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,6 @@ FROM base AS deploy
 ARG APP_USER=appuser
 RUN groupadd -r ${APP_USER} && useradd --no-log-init -r -g ${APP_USER} ${APP_USER}
 
-COPY --from=static_files /code/webpack-stats.json /code/
 # uWSGI will listen on this port
 EXPOSE 8000
 

--- a/hip/settings/base.py
+++ b/hip/settings/base.py
@@ -307,17 +307,6 @@ LOGOUT_REDIRECT_URL = "/"
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 BASE_URL = os.getenv("DOMAIN", "http://hip.caktus-built.com")
 
-WEBPACK_LOADER = {
-    "DEFAULT": {
-        "CACHE": not DEBUG,
-        "BUNDLE_DIR_NAME": "bundles/",  # must end with slash
-        "STATS_FILE": os.path.join(BASE_DIR, "webpack-stats.json"),
-        "POLL_INTERVAL": 0.1,
-        "TIMEOUT": None,
-        "IGNORE": [r".+\.hot-update.js", r".+\.map"],
-    }
-}
-
 VIDEOJS_HERO_ID = "video-hero"
 
 PHONENUMBER_DB_FORMAT = "NATIONAL"

--- a/hip/settings/deploy.py
+++ b/hip/settings/deploy.py
@@ -74,14 +74,3 @@ for backend in TEMPLATES:
 ADMINS = []  # we use AWS CloudWatch for this
 
 ### 3rd-party appplications
-
-WEBPACK_LOADER = {
-    "DEFAULT": {
-        "CACHE": True,
-        "BUNDLE_DIR_NAME": "js/bundles/",  # must end with slash
-        "STATS_FILE": os.path.join(BASE_DIR, "webpack-stats-production.json"),
-        # 'POLL_INTERVAL': 0.1,
-        # 'TIMEOUT': None,
-        "IGNORE": [r".+\.hot-update.js", r".+\.map"],
-    }
-}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "test": "jest",
     "dev": "gulp",
     "build": "NODE_ENV=production ./node_modules/.bin/webpack --progress --config webpack.config.js --bail",
-    "build:css": "sass ./hip/static/styles/bundle.scss:./static/styles/bundle.css --style compressed",
     "coverage": "jest --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
This PR makes adjustments after previous merge of this work caused develop branch to fail. Previous PR can be seen [here](https://github.com/caktus/philly-hip/pull/240).

These changes primarily remove lines dependent on `webpack-stats.json`, with some extra unnecessary Webpack-loader related code also removed.