### PR TITLE
192 update kubernetes [production-hot-fix]

### DIFF
--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -70,8 +70,8 @@ cloudformation_stack:
 
 k8s_cluster_type: aws
 k8s_context: "arn:aws:eks:us-east-1:061553509755:cluster/{{ cluster_name }}"
-k8s_ingress_nginx_chart_version: "3.39.0"
-k8s_cert_manager_chart_version: "v1.6.1"
+k8s_ingress_nginx_chart_version: "4.0.19"
+k8s_cert_manager_chart_version: "v1.7.2"
 k8s_letsencrypt_email: admin@caktusgroup.com
 k8s_iam_users: [noop]  # https://github.com/caktus/ansible-role-k8s-web-cluster/issues/17
 k8s_aws_fluent_bit_chart_version: "0.1.11"  # https://artifacthub.io/packages/helm/aws/aws-for-fluent-bit

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -74,7 +74,10 @@ k8s_ingress_nginx_chart_version: "4.0.19"
 k8s_cert_manager_chart_version: "v1.7.2"
 k8s_letsencrypt_email: admin@caktusgroup.com
 k8s_iam_users: [noop]  # https://github.com/caktus/ansible-role-k8s-web-cluster/issues/17
-k8s_aws_fluent_bit_chart_version: "0.1.11"  # https://artifacthub.io/packages/helm/aws/aws-for-fluent-bit
+# aws-for-fluent-bit
+# - https://github.com/aws/eks-charts/tree/master/stable/aws-for-fluent-bit
+# - https://artifacthub.io/packages/helm/aws/aws-for-fluent-bit
+k8s_aws_fluent_bit_chart_version: "0.1.18"
 
 # ----------------------------------------------------------------------------
 # caktus.django-k8s: Shared configuration variables for staging and production

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -2,13 +2,13 @@
 - src: https://github.com/caktus/ansible-role-aws-web-stacks
   name: caktus.aws-web-stacks
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
-  version: v1.1.0
+  version: v1.3.0
   name: caktus.k8s-web-cluster
 # Note: caktus.django-k8s version 1.4.0 has been released, but deploys fail due to issue:
 # msg: Failed to find exact match for rabbitmq.com/v1beta1.RabbitmqCluster by [kind, name, singularName, shortNames]
 - src: https://github.com/caktus/ansible-role-django-k8s
   name: caktus.django-k8s
-  version: v1.3.0
+  version: v1.5.0
 - src: https://github.com/caktus/ansible-role-k8s-hosting-services
   name: caktus.k8s-hosting-services
   version: v0.3.0

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -2,19 +2,20 @@
 -c ../base/base.txt
 
 pyyaml
-black
+black==22.6.0
 isort
 ipython
 jupyterlab
 
 # deploy
+ansible==5.9.0
 invoke-kubesae==0.0.16
-troposphere
 
 # AWS tools
 awscli
 awslogs
-openshift
+openshift==0.12
+kubernetes==12.0.0
 kubernetes-validate
 
 pre-commit

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -14,6 +14,7 @@ invoke-kubesae==0.0.16
 # AWS tools
 awscli
 awslogs
+Jinja2==3.0.3
 openshift==0.12
 kubernetes==12.0.0
 kubernetes-validate

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -201,8 +201,9 @@ jdcal==1.4.1
     #   openpyxl
 jedi==0.18.0
     # via ipython
-jinja2==2.11.3
+jinja2==3.0.3
     # via
+    #   -r requirements/dev/dev.in
     #   ansible-core
     #   jupyter-server
     #   jupyterlab
@@ -262,7 +263,7 @@ markuppy==1.14
     # via
     #   -c requirements/dev/../base/base.txt
     #   tablib
-markupsafe==1.1.1
+markupsafe==2.1.1
     # via jinja2
 mccabe==0.6.1
     # via flake8

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -4,9 +4,11 @@
 #
 #    pip-compile --output-file=requirements/dev/dev.txt requirements/dev/dev.in
 #
-ansible==2.10.7
-    # via invoke-kubesae
-ansible-base==2.10.5
+ansible==5.9.0
+    # via
+    #   -r requirements/dev/dev.in
+    #   invoke-kubesae
+ansible-core==2.12.7
     # via ansible
 anyascii==0.1.7
     # via
@@ -15,9 +17,7 @@ anyascii==0.1.7
 anyio==2.1.0
     # via jupyter-server
 appdirs==1.4.4
-    # via
-    #   black
-    #   virtualenv
+    # via virtualenv
 appnope==0.1.2
     # via
     #   -r requirements/dev/dev.in
@@ -47,7 +47,7 @@ beautifulsoup4==4.8.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-black==20.8b1
+black==22.6.0
     # via -r requirements/dev/dev.in
 bleach==3.3.0
     # via nbconvert
@@ -76,16 +76,12 @@ cffi==1.14.5
     #   cryptography
 cfgv==3.2.0
     # via pre-commit
-cfn-flip==1.2.3
-    # via troposphere
 chardet==4.0.0
     # via
     #   -c requirements/dev/../base/base.txt
     #   requests
-click==7.1.2
-    # via
-    #   black
-    #   cfn-flip
+click==8.1.3
+    # via black
 colorama==0.4.3
     # via
     #   awscli
@@ -97,7 +93,7 @@ coverage==5.4
 cryptography==3.4.7
     # via
     #   -c requirements/dev/../base/base.txt
-    #   ansible-base
+    #   ansible-core
 decorator==4.4.2
     # via ipython
 defusedxml==0.7.1
@@ -207,7 +203,7 @@ jedi==0.18.0
     # via ipython
 jinja2==2.11.3
     # via
-    #   ansible-base
+    #   ansible-core
     #   jupyter-server
     #   jupyterlab
     #   jupyterlab-server
@@ -252,8 +248,10 @@ jupyterlab-pygments==0.1.2
     # via nbconvert
 jupyterlab-server==2.2.1
     # via jupyterlab
-kubernetes==11.0.0
-    # via openshift
+kubernetes==12.0.0
+    # via
+    #   -r requirements/dev/dev.in
+    #   openshift
 kubernetes-validate==1.19.0
     # via -r requirements/dev/dev.in
 l18n==2020.6.1
@@ -304,11 +302,11 @@ openpyxl==3.0.6
     # via
     #   -c requirements/dev/../base/base.txt
     #   tablib
-openshift==0.11.2
+openshift==0.12
     # via -r requirements/dev/dev.in
 packaging==20.9
     # via
-    #   ansible-base
+    #   ansible-core
     #   bleach
     #   jupyterlab
     #   jupyterlab-server
@@ -317,7 +315,7 @@ pandocfilters==1.4.3
     # via nbconvert
 parso==0.8.1
     # via jedi
-pathspec==0.8.1
+pathspec==0.9.0
     # via black
 pexpect==4.8.0
     # via ipython
@@ -327,6 +325,8 @@ pillow==8.2.0
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
+platformdirs==2.5.2
+    # via black
 pluggy==0.13.1
     # via pytest
 pre-commit==2.10.1
@@ -405,9 +405,8 @@ pyyaml==5.4.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   -r requirements/dev/dev.in
-    #   ansible-base
+    #   ansible-core
     #   awscli
-    #   cfn-flip
     #   kubernetes
     #   kubernetes-validate
     #   pre-commit
@@ -417,8 +416,6 @@ pyzmq==22.0.3
     #   jupyter-client
     #   jupyter-server
     #   notebook
-regex==2020.11.13
-    # via black
 requests==2.25.1
     # via
     #   -c requirements/dev/../base/base.txt
@@ -430,11 +427,13 @@ requests-oauthlib==1.3.0
     # via
     #   -c requirements/dev/../base/base.txt
     #   kubernetes
+resolvelib==0.5.4
+    # via ansible-core
 rsa==4.5
     # via
     #   awscli
     #   google-auth
-ruamel.yaml==0.16.12
+ruamel-yaml==0.16.12
     # via openshift
 s3transfer==0.4.2
     # via
@@ -450,7 +449,6 @@ six==1.15.0
     #   -c requirements/dev/../base/base.txt
     #   argon2-cffi
     #   bleach
-    #   cfn-flip
     #   google-auth
     #   html5lib
     #   jsonschema
@@ -491,9 +489,10 @@ text-unidecode==1.3
     # via faker
 toml==0.10.2
     # via
-    #   black
     #   pre-commit
     #   pytest
+tomli==2.0.1
+    # via black
 tornado==6.1
     # via
     #   ipykernel
@@ -513,11 +512,7 @@ traitlets==5.0.5
     #   nbconvert
     #   nbformat
     #   notebook
-troposphere==2.6.3
-    # via -r requirements/dev/dev.in
-typed-ast==1.4.2
-    # via black
-typing-extensions==3.7.4.3
+typing-extensions==4.2.0
     # via black
 urllib3==1.26.4
     # via


### PR DESCRIPTION
Update web cluster, k8s, helm chart, and cert-manager

Includes:
- Update Kubernetes v1.20 -> v1.22
- Update NGINX Ingress Controller 3.39.0 -> 4.0.19
-  Update Django-k8s v1.3.0 -> v1.5.0
- Update certificate manager v1.6.1 -> v1.7.2
- Update fluentbit chart version v0.1.11 -> v0.1.18
- Update ansible v2.10.5 -> v5.9.0
- Update jinga2 v2.11.3 -> v3.0.3

Caktus Hosting Services ticket 
- caktus/caktus-hosting-services#192