### PR TITLE
Ignore webpack-stats.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ env-local.sh
 .vsls.json
 .envrc
 .direnv
+webpack-stats.json
 
 # Project Static Files
 node_modules/*


### PR DESCRIPTION
This PR adds `webpack-stats.json` to the `.gitignore` file, so that we don't accidentally commit it.