### PR TITLE
[DIS-1798] Adds <h1> tag to base.html, which applies to every page across the site

### DIFF
--- a/hip/static/styles/pages/base.scss
+++ b/hip/static/styles/pages/base.scss
@@ -43,3 +43,14 @@ body {
 .full-height-hip {
   min-height: 100vh;
 }
+
+.visually-hidden {
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%); /* browsers in the future */
+  height: 1px; 
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/hip/static/styles/pages/base.scss
+++ b/hip/static/styles/pages/base.scss
@@ -44,6 +44,7 @@ body {
   min-height: 100vh;
 }
 
+// This class allows us to hide content from sighted users, while allowing the content to remain accessible via screen reader.
 .visually-hidden {
   clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
   clip: rect(1px, 1px, 1px, 1px);

--- a/hip/templates/base.html
+++ b/hip/templates/base.html
@@ -50,6 +50,8 @@
     </noscript>
     <!-- End Google Tag Manager no script [phila.gov] -->
 
+    <h1 class="visually-hidden">Health Information Portal (HIP)</h1>
+
     {% wagtailuserbar 'bottom-left' %}
     {% include 'includes/header.html' %}
     <div class="columns is-desktop">


### PR DESCRIPTION
[Ticket](https://caktus.atlassian.net/browse/DIS-1798?atlOrigin=eyJpIjoiNjMzZDEwYjBkMDA0NDZmMzlhNzRjOWJiMjgxZTI4YjkiLCJwIjoiaiJ9)

This PR 
- Adds an `<h1>` element to every page across the site. It is the same on every page, "Health Information Portal (HIP)".
- Adds a `visually-hidden` class, so that it can be hidden from sighted users, but visible to users with screen readers.

Note: It may be worth revisiting the idea of adding a unique `<h1>` tag to each page (ex. "Health Alerts", "Data and Reports", "Disease Control", etc). For now, this solution is the one requested in the ticket, where all pages have the same `<h1>` element.