### PR TITLE
[DIS-1801] Improves color contrast of right-hand nav and adds arrow indicator

### DIFF
--- a/hip/static/styles/pages/static_page.scss
+++ b/hip/static/styles/pages/static_page.scss
@@ -39,9 +39,18 @@
 
 .right-scroll-link-hip {
   // links are grey unless they are current
-  color: $grey;
+  color: $dark-grey;
 
   &.is-current-hip {
-    color: $light-blue;
+    color: $dark-blue;
+
+    // This creates an arrow to indicate the active heading without relying on color alone.
+    ::before {
+      content:"\27A4";
+      border-style: solid;
+      border-color: transparent;
+      position: absolute;
+      left: -12px;
+    }
   }
 }


### PR DESCRIPTION
[Ticket](https://caktus.atlassian.net/browse/DIS-1801?atlOrigin=eyJpIjoiMjJkODI4NzdmMDhmNGJlMzhkNDhkODNhNzM3M2E5NjgiLCJwIjoiaiJ9)

This PR:
- Changes the font color for headings in the Right-hand nav (as on the Posters page) to provide better contrast with the white background
- Adds an arrow to indicate the active heading, as contrast between active heading color and non-active heading color was too low

Note: The arrow indicator was not requested, and can be removed or altered if requested. It or some other non-color-based indicator will be required for full accessibility