### PR TITLE
Upgrade Django To Latest Bugfix Version

### DIFF
--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -33,7 +33,7 @@ diff-match-patch==20200713
     # via django-import-export
 dj-database-url==0.5.0
     # via -r requirements/base/base.in
-django==3.2.15
+django==3.2.16
     # via
     #   -r requirements/base/base.in
     #   django-appconf

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -103,7 +103,7 @@ defusedxml==0.7.1
     #   odfpy
 distlib==0.3.1
     # via virtualenv
-django==3.2.15
+django==3.2.16
     # via
     #   -c requirements/dev/../base/base.txt
     #   django-debug-toolbar


### PR DESCRIPTION
This pull request upgrades Django to the latest bugfix version (3.2.16), to include [one more Django bugfix](https://docs.djangoproject.com/en/4.1/releases/3.2.16/).