### PR TITLE
Upgrade Django version

### DIFF
--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -33,7 +33,7 @@ diff-match-patch==20200713
     # via django-import-export
 dj-database-url==0.5.0
     # via -r requirements/base/base.in
-django==3.2.16
+django==3.2.17
     # via
     #   -r requirements/base/base.in
     #   django-appconf

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -98,7 +98,7 @@ defusedxml==0.7.1
     #   odfpy
 distlib==0.3.6
     # via virtualenv
-django==3.2.16
+django==3.2.17
     # via
     #   -c requirements/dev/../base/base.txt
     #   django-debug-toolbar


### PR DESCRIPTION
Upgrades the Django version to avoid a zero day vulnerability. See [here ](https://www.djangoproject.com/weblog/2023/feb/01/security-releases/)for more info.