### PR TITLE
Deploy descheduler, upgrade Helm charts

### DIFF
--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -128,3 +128,18 @@ k8s_s3_private_bucket: "{{ k8s_s3_namespace }}-philly-private-assets"
 k8s_ci_username: hip-ci-user
 k8s_ci_repository_arn: "arn:aws:ecr:us-east-1:061553509755:repository/philly-hip-stack-applicationrepository-kk92mehevd86"
 k8s_ci_vault_password_arn: "arn:aws:secretsmanager:us-east-1:061553509755:secret:hip-ansible-vault-password-JYhbao"
+
+# Install Descheduler to attempt to spread out pods again after node failures
+k8s_install_descheduler: yes
+# You must set the k8s_descheduler_chart_version to match the Kubernetes
+# node version (0.23.x -> K8s 1.23.x); see:
+# https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
+k8s_descheduler_chart_version: v0.22.1
+# See values.yaml for options:
+# https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
+k8s_descheduler_release_values:
+  deschedulerPolicy:
+    strategies:
+      # During upgrades or reboots, don't pre-emptively drain a node.
+      RemovePodsViolatingNodeTaints:
+        enabled: false

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -70,8 +70,8 @@ cloudformation_stack:
 
 k8s_cluster_type: aws
 k8s_context: "arn:aws:eks:us-east-1:061553509755:cluster/{{ cluster_name }}"
-k8s_ingress_nginx_chart_version: "4.0.19"
-k8s_cert_manager_chart_version: "v1.7.2"
+k8s_ingress_nginx_chart_version: "4.4.2"
+k8s_cert_manager_chart_version: "v1.11.0"
 k8s_letsencrypt_email: admin@caktusgroup.com
 k8s_iam_users: [noop]  # https://github.com/caktus/ansible-role-k8s-web-cluster/issues/17
 # aws-for-fluent-bit

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -2,7 +2,7 @@
 - src: https://github.com/caktus/ansible-role-aws-web-stacks
   name: caktus.aws-web-stacks
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
-  version: v1.3.0
+  version: v1.4.0
   name: caktus.k8s-web-cluster
 # Note: caktus.django-k8s version 1.4.0 has been released, but deploys fail due to issue:
 # msg: Failed to find exact match for rabbitmq.com/v1beta1.RabbitmqCluster by [kind, name, singularName, shortNames]

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -11,4 +11,4 @@
   version: v1.5.0
 - src: https://github.com/caktus/ansible-role-k8s-hosting-services
   name: caktus.k8s-hosting-services
-  version: v0.3.0
+  version: v0.9.0


### PR DESCRIPTION
### Issue

https://app.clickup.com/t/8677fztpa

### Summary

- [x] descheduler chart install: v0.22.1
- [x] ingress-nginx chart upgrade: v4.0.19 → v4.4.2
- [x] cert-manager chart upgrade: v1.7.2 → v1.11.0
- [x] AWS NodeGroup AMI upgrade: 1.22.9-20220629 → 1.22.17-20230217

#### Deploy descheduler
```
❯ inv deploy.install
❯ inv deploy.playbook deploy-cluster.yml
❯ kubectl -n kube-system get cronjob
NAME          SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
descheduler   */2 * * * *   False     0        34s             3m54s
```
#### Upgrade ingress-nginx and cert-manager
```
❯ inv staging deploy.playbook -n deploy-cluster.yml
❯ kubectl -n ingress-nginx get pod -o wide
NAME                                        READY   STATUS    RESTARTS   AGE    IP           NODE                         NOMINATED NODE   READINESS GATES
ingress-nginx-controller-7b454df556-clllc   1/1     Running   0          95s    10.0.14.73   ip-10-0-12-45.ec2.internal   <none>           <none>
ingress-nginx-controller-7b454df556-t87fq   1/1     Running   0          115s   10.0.10.8    ip-10-0-9-16.ec2.internal    <none>           <none>

❯ helm -n ingress-nginx list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ingress-nginx   ingress-nginx   4               2023-02-24 20:16:34.295772967 +0000 UTC deployed        ingress-nginx-4.4.2     1.5.1  

❯ helm -n cert-manager list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    4               2023-02-24 20:17:43.123898388 +0000 UTC deployed        cert-manager-v1.11.0    v1.11.0    
```


New nodes running (AMI upgrade took about 10 mins): 
![Screenshot 2023-02-24 at 3 35 06 PM](https://user-images.githubusercontent.com/87770895/221286415-89a2cb50-0732-47e2-a2c3-2ab0c0e8f13d.png)
