### PR TITLE
Avoid Server Error On Health Alerts Without Alert File

### DIFF
--- a/apps/health_alerts/models.py
+++ b/apps/health_alerts/models.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.db import models
+from django.http import Http404
 from django.shortcuts import redirect
 
 from phonenumber_field.modelfields import PhoneNumberField
@@ -108,6 +109,10 @@ class HealthAlertDetailPage(HipBasePage):
         return ""
 
     def serve(self, request):
+        """Return the URL for the HealthAlertDetailPage's alert_file (or a 404 page)."""
+        # If the HealthAlertDetailPage does not have an alert_file, then return a 404 page.
+        if not self.alert_file:
+            raise Http404()
         return redirect(self.alert_file.url)
 
     # Because we have overridden the serve() method of this model, we also need to

--- a/apps/health_alerts/tests/test_models.py
+++ b/apps/health_alerts/tests/test_models.py
@@ -1,0 +1,51 @@
+from django.http import Http404
+
+import pytest
+
+from apps.hip.tests.factories import DocumentFactory
+
+from .factories import HealthAlertDetailPageFactory
+
+
+@pytest.mark.parametrize(
+    "page_is_live,page_has_alert_file,expected_response_status_code",
+    [
+        (True, True, 302),
+        (True, False, 404),
+        (False, True, 302),
+        (False, False, 404),
+    ],
+)
+def test_serve_health_alert_detail_page(
+    db,
+    client,
+    request,
+    page_is_live,
+    page_has_alert_file,
+    expected_response_status_code,
+):
+    """Assert that loading a HealthAlertDetailPage does not cause a server error."""
+    health_alert_page = HealthAlertDetailPageFactory(live=page_is_live, alert_file=None)
+    if page_has_alert_file:
+        health_alert_page.alert_file = DocumentFactory()
+        health_alert_page.save()
+
+    # Call the serve() method, and verify that the response is as expected.
+    if expected_response_status_code == 404:
+        with pytest.raises(Http404):
+            health_alert_page.serve(request)
+    else:
+        response_serve = health_alert_page.serve(request)
+        assert expected_response_status_code == response_serve.status_code
+        if expected_response_status_code == 302:
+            assert health_alert_page.alert_file.url == response_serve.url
+
+    # Call the serve_preview() method, and verify that the response is as expected.
+    if expected_response_status_code == 404:
+        with pytest.raises(Http404):
+            health_alert_page.serve_preview(request, "")
+    else:
+        response_serve_preview = health_alert_page.serve_preview(request, "")
+        assert expected_response_status_code == response_serve_preview.status_code
+        if expected_response_status_code == 302:
+            assert health_alert_page.alert_file.url == response_serve_preview.url


### PR DESCRIPTION
ClickUp ticket: https://app.clickup.com/t/8684y6f05

Previously, the `HealthAlertDetailPage.alert_file` field was optional, but serving a health alert page redirected users to the `HealthAlertDetailPage`’s `alert_file`’s URL. As a result, loading a `HealthAlertDetailPage` with an empty `alert_file caused a server error.

Now, if a `HealthAlertDetailPage` has an empty `alert_file`, a generic 404 page will be returned (whether in the Wagtail preview panel, or on the site).

Note: it appears that this server error can only be triggered for Wagtail users. Regular (non-authenticated) users can click on the health alerts from the health alerts list page ([which only have a link if the `HealthAlertDetailPage` has an `alert_file`](https://github.com/caktus/philly-hip/blob/develop/apps/hip/templates/includes/health_alert_table_row.html#L5-L10).

Note: I first tried to make the `HealthAlertDetailPage.alert_file` field required, but it appears that a number of `HealthAlertDetailPage`s have an empty `alert_file` field, and that may be meaningful data (a health alert was issued, but we don’t have a copy of the alert), so I decided to leave the `alert_file` field optional, rather than trying to programmatically decide what should happen for those already-existing objects in the database.

