### PR TITLE
Use Custom 404 And 500 Templates

### DIFF
--- a/hip/templates/404.html
+++ b/hip/templates/404.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2 class="is-size-2"><strong>The page was not found.</strong></h2>
+{% endblock content %}

--- a/hip/templates/500.html
+++ b/hip/templates/500.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2 class="is-size-2"><strong>There was an error.</strong></h2>
+{% endblock content %}

--- a/hip/urls.py
+++ b/hip/urls.py
@@ -16,6 +16,11 @@ from apps.notifications import views as notifications_views
 from apps.search import views as search_views
 
 
+# Explicitly define our handlers for 404-status-code and 500-status-code responses.
+handler404 = "apps.hip.views.handler404"
+handler500 = "apps.hip.views.handler500"
+
+
 urlpatterns = [
     path("search/", search_views.search, name="search"),
     path(


### PR DESCRIPTION
ClickUp ticket: https://app.clickup.com/t/8684yagqm

As noted in the ClickUp ticket, the site is currently not defining a template to use for 404 (or a 500) status code responses. As a result, the page for such responses looks not great.

It turns out the code actually has functions for handling 404 and 500 status-code responses, but they weren't hooked up as Django expected, and the templates (404.html and 500.html) didn't exist.
This pull request:
 - hooks up the handlers for 404 and 500 status-code responses [as expected by Django](https://docs.djangoproject.com/en/4.2/topics/http/urls/#error-handling)
 - adds the necessary HTML templates (404.html and 500.html)
 
To test locally:
 - set the following in your `local.py` settings file:
```
DEBUG=False
STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
```
To see the 404 page:
 - visit a URL that doesn't exist
To see the 500 page:
 - add some code that causes an error
   - for example, in `apps/hip/views.py`, just below the `def handler404(request, *args, **argv):` line, add something like `1/0`, then visit a URL that doesn't exist
 
TODO:
 - make the templates look better