### PR TITLE
Fix build (pyyaml)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - pyyaml-fix
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - pyyaml-fix
 
 jobs:
   deploy:

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -17,8 +17,8 @@ django-sass-processor
 django-phonenumber-field
 django-honeypot
 whitenoise
-boto3==1.26.87
-botocore==1.29.87
+boto3==1.28.4
+botocore==1.31.4
 libsass
 phonenumberslite
 pdfid

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -11,6 +11,7 @@ django-compressor
 django-taggit
 django-ipware
 django-import-export
+pyyaml==6.0.1
 
 django-sass-processor
 

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -10,9 +10,9 @@ asgiref==3.3.4
     # via django
 beautifulsoup4==4.8.2
     # via wagtail
-boto3==1.26.87
+boto3==1.28.4
     # via -r requirements/base/base.in
-botocore==1.29.87
+botocore==1.31.4
     # via
     #   -r requirements/base/base.in
     #   boto3
@@ -137,8 +137,10 @@ pytz==2021.1
     #   django
     #   django-modelcluster
     #   l18n
-pyyaml==5.4.1
-    # via tablib
+pyyaml==6.0.1
+    # via
+    #   -r requirements/base/base.in
+    #   tablib
 rcssmin==1.0.6
     # via django-compressor
 requests==2.25.1

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -1,7 +1,7 @@
 # Dev requirements
 -c ../base/base.txt
 
-pyyaml
+pyyaml==6.0.1
 black==22.6.0
 isort
 ipython
@@ -12,7 +12,7 @@ ansible==7.6.0
 invoke-kubesae==0.1.0
 
 # AWS tools
-awscli==1.27.87
+awscli==1.29.4
 awslogs
 Jinja2==3.0.3
 openshift==0.12

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -33,7 +33,7 @@ attrs==20.3.0
     # via
     #   jsonschema
     #   pytest
-awscli==1.27.87
+awscli==1.29.4
     # via -r requirements/dev/dev.in
 awslogs==0.14.0
     # via -r requirements/dev/dev.in
@@ -49,12 +49,12 @@ black==22.6.0
     # via -r requirements/dev/dev.in
 bleach==3.3.0
     # via nbconvert
-boto3==1.26.87
+boto3==1.28.4
     # via
     #   -c requirements/dev/../base/base.txt
     #   awslogs
     #   invoke-kubesae
-botocore==1.29.87
+botocore==1.31.4
     # via
     #   -c requirements/dev/../base/base.txt
     #   awscli
@@ -294,7 +294,7 @@ openpyxl==3.1.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-openshift==0.12
+openshift==0.12.0
     # via -r requirements/dev/dev.in
 packaging==20.9
     # via
@@ -395,7 +395,7 @@ pytz==2021.1
     #   django
     #   django-modelcluster
     #   l18n
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   -r requirements/dev/dev.in


### PR DESCRIPTION
This fixes an error building PyYAML 5.4.1, which picked up the new cython 3, with which it is not compatible. Philly-hip doesn't use PyYAML directly, it is needed by deploy-related packages, including AWS CLI.
`PyYAML == 6.0.1` is now pinned in `base.in`.