### PR TITLE
Avoid Memory Leaks [No ClickUp ticket]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,9 @@ ENV UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_HTTP_AUTO_CHUNKED=1 UWSGI_HTTP_KEEPALI
 # Number of uWSGI workers and threads per worker (customize as needed):
 ENV UWSGI_WORKERS=2 UWSGI_THREADS=4
 
+# Reload workers after the specified amount of managed requests (avoid memory leaks)
+ENV UWSGI_MAX_REQUESTS=1000
+
 # uWSGI static file serving configuration (customize or comment out if not needed):
 ENV UWSGI_STATIC_MAP="/static/=/code/static/" UWSGI_STATIC_EXPIRES_URI="/static/.*\.[a-f0-9]{12,}\.(css|js|png|jpg|jpeg|gif|ico|woff|ttf|otf|svg|scss|map|txt) 315360000"
 


### PR DESCRIPTION
This PR enables reloading workers after a specified amount of managed requests - 1000 - to avoid memory leaks.