### PR TITLE
Kubernetes Upgrade v1.25 -> v1.29 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,8 @@ name: Lint and Test code
 
 on:
   pull_request:
-  schedule:
-    # run once a week on early monday mornings
-    - cron: '22 2 * * 1'
+  push:
+    branches: [main, develop]
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,8 +121,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   openssh-client -- for git over SSH
 #   sudo -- to run commands as superuser
 #   vim -- enhanced vi editor for commits
-ENV KUBE_CLIENT_VERSION="v1.25.10"
-ENV HELM_VERSION="3.12.0"
+ENV KUBE_CLIENT_VERSION="v1.29.3"
+ENV HELM_VERSION="3.14.4"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     --mount=type=cache,mode=0755,target=/root/.cache/pip \
     set -ex \

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ These instructions assume that you will be working with dockerized services.
 First add the following line to your `.env` file:
 
 ```sh
-(hip)$ echo "DATABASE_URL=postgres://postgres@127.0.0.1:5433/hip" >> .env
+(hip)$ echo "DATABASE_URL=postgres://postgres@127.0.0.1:5432/hip" >> .env
 ```
 
 The `docker-compose.yml` sets up environment variables in a file, ``.postgres``.

--- a/apps/reports/tests/test_models.py
+++ b/apps/reports/tests/test_models.py
@@ -84,23 +84,28 @@ def test_datareportslistpage_context_only_external_reports(db, rf):
         "last_updated": date(year=2021, month=1, day=1),
         "external": True,
     }
+    external_reports_data = [
+        {
+            "type": "external_reports",  # Block type
+            "value": {
+                "title": external_report_hiv["title"],
+                "url": external_report_hiv["url"],
+                "update_frequency": external_report_hiv["update_frequency"],
+                "last_updated": external_report_hiv["last_updated"],
+            },
+        },
+        {
+            "type": "external_reports",
+            "value": {
+                "title": external_report_hep_a["title"],
+                "url": external_report_hep_a["url"],
+                "update_frequency": external_report_hep_a["update_frequency"],
+                "last_updated": external_report_hep_a["last_updated"],
+            },
+        },
+    ]
     reports_list_page = DataReportListPageFactory(
-        external_reports__0__external_reports__title=external_report_hiv["title"],
-        external_reports__0__external_reports__url=external_report_hiv["url"],
-        external_reports__0__external_reports__update_frequency=external_report_hiv[
-            "update_frequency"
-        ],
-        external_reports__0__external_reports__last_updated=external_report_hiv[
-            "last_updated"
-        ],
-        external_reports__1__external_reports__title=external_report_hep_a["title"],
-        external_reports__1__external_reports__url=external_report_hep_a["url"],
-        external_reports__1__external_reports__update_frequency=external_report_hep_a[
-            "update_frequency"
-        ],
-        external_reports__1__external_reports__last_updated=external_report_hep_a[
-            "last_updated"
-        ],
+        external_reports=external_reports_data
     )
 
     context = reports_list_page.get_context(rf.get("/someurl/"))
@@ -127,15 +132,19 @@ def test_datareportslistpage_context_internal_and_external_reports(db, rf):
         "last_updated": "2021-01-01",
         "external": True,
     }
+    external_reports_data = [
+        {
+            "type": "external_reports",
+            "value": {
+                "title": external_report_hiv["title"],
+                "url": external_report_hiv["url"],
+                "update_frequency": external_report_hiv["update_frequency"],
+                "last_updated": external_report_hiv["last_updated"],
+            },
+        },
+    ]
     reports_list_page = DataReportListPageFactory(
-        external_reports__0__external_reports__title=external_report_hiv["title"],
-        external_reports__0__external_reports__url=external_report_hiv["url"],
-        external_reports__0__external_reports__update_frequency=external_report_hiv[
-            "update_frequency"
-        ],
-        external_reports__0__external_reports__last_updated=external_report_hiv[
-            "last_updated"
-        ],
+        external_reports=external_reports_data
     )
     # Create  some internal reports (DataReportDetailPages) for the DataReportListPage.
     tuberculosis = DiseaseAndConditionDetailPageFactory(title="Tuberculosis")

--- a/deploy/deploy-cluster.yml
+++ b/deploy/deploy-cluster.yml
@@ -10,7 +10,7 @@
   tasks:
     - name: Add AWS for fluent bit helm chart (centralized logging)
       tags: fluentbit
-      community.kubernetes.helm:
+      kubernetes.core.helm:
         context: "{{ k8s_context|mandatory }}"
         kubeconfig: "{{ k8s_kubeconfig }}"
         chart_repo_url: "https://aws.github.io/eks-charts"
@@ -29,7 +29,7 @@
         wait: yes
     - name: Create Amazon CloudWatch Metrics namespace
       tags: cloudwatch
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         context: "{{ k8s_context|mandatory }}"
         kubeconfig: "{{ k8s_kubeconfig }}"
         name: "{{ k8s_aws_cloudwatch_metrics_namespace }}"
@@ -38,7 +38,7 @@
         state: present
     - name: Add AWS CloudWatch Metrics helm chart (monitoring)
       tags: cloudwatch
-      community.kubernetes.helm:
+      kubernetes.core.helm:
         context: "{{ k8s_context|mandatory }}"
         kubeconfig: "{{ k8s_kubeconfig }}"
         chart_repo_url: "https://aws.github.io/eks-charts"
@@ -54,6 +54,7 @@
       tags: cloudwatch
       amazon.aws.cloudwatch_metric_alarm:
         state: present
+        aws_profile: "{{ aws_profile }}"
         region: us-east-1
         name: "{{ item.name }}"
         description: "{{ item.description }}"

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -211,7 +211,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.25.2
+k8s_descheduler_chart_version: v0.29.0
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -85,7 +85,7 @@ k8s_iam_users: [noop]  # https://github.com/caktus/ansible-role-k8s-web-cluster/
 # aws-for-fluent-bit
 # - https://github.com/aws/eks-charts/tree/master/stable/aws-for-fluent-bit
 # - https://artifacthub.io/packages/helm/aws/aws-for-fluent-bit
-k8s_aws_fluent_bit_chart_version: "0.1.18"
+k8s_aws_fluent_bit_chart_version: "0.1.32"
 # aws-cloudwatch-metrics:
 # - https://github.com/aws/eks-charts/tree/master/stable/aws-cloudwatch-metrics
 # - https://artifacthub.io/packages/helm/aws/aws-cloudwatch-metrics

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -78,8 +78,8 @@ cloudformation_stack:
 k8s_cluster_type: aws
 # aws eks describe-cluster --name=philly-hip-stack-cluster --query 'cluster.arn'
 k8s_context: "arn:aws:eks:us-east-1:061553509755:cluster/{{ cluster_name }}"
-k8s_ingress_nginx_chart_version: "4.6.0"
-k8s_cert_manager_chart_version: "v1.11.1"
+k8s_ingress_nginx_chart_version: "4.9.1"
+k8s_cert_manager_chart_version: "v1.14.3"
 k8s_letsencrypt_email: admin@caktusgroup.com
 k8s_iam_users: [noop]  # https://github.com/caktus/ansible-role-k8s-web-cluster/issues/17
 # aws-for-fluent-bit
@@ -89,7 +89,7 @@ k8s_aws_fluent_bit_chart_version: "0.1.18"
 # aws-cloudwatch-metrics:
 # - https://github.com/aws/eks-charts/tree/master/stable/aws-cloudwatch-metrics
 # - https://artifacthub.io/packages/helm/aws/aws-cloudwatch-metrics
-k8s_aws_cloudwatch_metrics_chart_version: "0.0.9"
+k8s_aws_cloudwatch_metrics_chart_version: "0.0.11"
 k8s_aws_cloudwatch_metrics_namespace: amazon-cloudwatch
 
 # ----------------------------------------------------------------------------

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -2,13 +2,13 @@
 - src: https://github.com/caktus/ansible-role-aws-web-stacks
   name: caktus.aws-web-stacks
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
-  version: v1.5.0
+  version: v1.6.0
   name: caktus.k8s-web-cluster
 # Note: caktus.django-k8s version 1.4.0 has been released, but deploys fail due to issue:
 # msg: Failed to find exact match for rabbitmq.com/v1beta1.RabbitmqCluster by [kind, name, singularName, shortNames]
 - src: https://github.com/caktus/ansible-role-django-k8s
   name: caktus.django-k8s
-  version: v1.6.0
+  version: v1.9.0
 - src: https://github.com/caktus/ansible-role-k8s-hosting-services
   name: caktus.k8s-hosting-services
-  version: v0.11.0
+  version: v0.12.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       args:
         USER_UID: ${USER_UID:-1000}
         USER_GID: ${USER_GID:-1000}
-    command: ["sleep", "infinity"]
+    command: [ "sleep", "infinity" ]
     links:
       - db:db
     ports:

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -18,8 +18,8 @@ django-sass-processor
 django-phonenumber-field
 django-honeypot
 whitenoise
-boto3==1.28.4
-botocore==1.31.4
+boto3==1.34.104
+botocore==1.34.104
 libsass
 phonenumberslite
 pdfid

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -10,9 +10,9 @@ asgiref==3.3.4
     # via django
 beautifulsoup4==4.8.2
     # via wagtail
-boto3==1.28.4
+boto3==1.34.104
     # via -r requirements/base/base.in
-botocore==1.31.4
+botocore==1.34.104
     # via
     #   -r requirements/base/base.in
     #   boto3
@@ -152,7 +152,7 @@ requests-oauthlib==1.3.0
     # via social-auth-core
 rjsmin==1.1.0
     # via django-compressor
-s3transfer==0.6.1
+s3transfer==0.10.1
     # via boto3
 six==1.15.0
     # via

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -2,22 +2,22 @@
 -c ../base/base.txt
 
 pyyaml==6.0.1
-black==22.6.0
+black==24.4.2
 isort
 ipython
 jupyterlab
 
 # deploy
-ansible==7.6.0
+ansible==9.5.1
 invoke-kubesae==0.1.0
 
 # AWS tools
-awscli==1.29.4
+awscli==1.32.104
 awslogs
 Jinja2==3.0.3
-openshift==0.12
+openshift==0.13.2
 kubernetes==12.0.0
-kubernetes-validate~=1.25.0
+kubernetes-validate~=1.29.1
 
 pre-commit
 coverage

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -14,38 +14,41 @@ anyascii==0.1.7
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-anyio==2.1.0
+anyio==3.7.1
     # via jupyter-server
-appnope==0.1.2
+appnope==0.1.4
     # via -r requirements/dev/dev.in
-argon2-cffi==20.1.0
-    # via notebook
+argon2-cffi==23.1.0
+    # via
+    #   jupyter-server
+    #   nbclassic
+    #   notebook
+argon2-cffi-bindings==21.2.0
+    # via argon2-cffi
 asgiref==3.3.4
     # via
     #   -c requirements/dev/../base/base.txt
     #   django
-async-generator==1.10
-    # via nbclient
-attrs==20.3.0
+asttokens==2.4.1
+    # via stack-data
+attrs==23.2.0
     # via
     #   jsonschema
-    #   pytest
     #   referencing
 awscli==1.32.104
     # via -r requirements/dev/dev.in
 awslogs==0.14.0
     # via -r requirements/dev/dev.in
-babel==2.9.0
+babel==2.15.0
     # via jupyterlab-server
-backcall==0.2.0
-    # via ipython
 beautifulsoup4==4.8.2
     # via
     #   -c requirements/dev/../base/base.txt
+    #   nbconvert
     #   wagtail
 black==24.4.2
     # via -r requirements/dev/dev.in
-bleach==3.3.0
+bleach==6.1.0
     # via nbconvert
 boto3==1.34.104
     # via
@@ -58,7 +61,7 @@ botocore==1.34.104
     #   awscli
     #   boto3
     #   s3transfer
-cachetools==4.2.1
+cachetools==5.3.3
     # via google-auth
 certifi==2020.12.5
     # via
@@ -68,21 +71,23 @@ certifi==2020.12.5
 cffi==1.14.5
     # via
     #   -c requirements/dev/../base/base.txt
-    #   argon2-cffi
+    #   argon2-cffi-bindings
     #   cryptography
-cfgv==3.2.0
+cfgv==3.4.0
     # via pre-commit
 chardet==4.0.0
     # via
     #   -c requirements/dev/../base/base.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via black
-colorama==0.4.3
+colorama==0.4.6
     # via
     #   awscli
     #   invoke-kubesae
-coverage==5.4
+comm==0.2.2
+    # via ipykernel
+coverage[toml]==7.5.1
     # via
     #   -r requirements/dev/dev.in
     #   pytest-cov
@@ -90,13 +95,15 @@ cryptography==3.4.7
     # via
     #   -c requirements/dev/../base/base.txt
     #   ansible-core
-decorator==4.4.2
+debugpy==1.8.1
+    # via ipykernel
+decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   nbconvert
-distlib==0.3.6
+distlib==0.3.8
     # via virtualenv
 django==3.2.23
     # via
@@ -109,7 +116,7 @@ django==3.2.23
     #   django-treebeard
     #   djangorestframework
     #   wagtail
-django-debug-toolbar==3.7.0
+django-debug-toolbar==4.3.0
     # via -r requirements/dev/dev.in
 django-filter==2.4.0
     # via
@@ -135,72 +142,84 @@ djangorestframework==3.12.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-docutils==0.15.2
+docutils==0.16
     # via awscli
 draftjs-exporter==2.1.7
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-entrypoints==0.3
-    # via nbconvert
+entrypoints==0.4
+    # via jupyter-client
 et-xmlfile==1.0.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   openpyxl
-factory-boy==3.2.0
+exceptiongroup==1.2.1
+    # via
+    #   anyio
+    #   ipython
+    #   pytest
+executing==2.0.1
+    # via stack-data
+factory-boy==3.3.0
     # via
     #   -r requirements/dev/dev.in
     #   pytest-factoryboy
     #   wagtail-factories
-faker==15.3.2
+faker==25.2.0
     # via factory-boy
-filelock==3.8.1
+fastjsonschema==2.19.1
+    # via nbformat
+filelock==3.14.0
     # via virtualenv
-flake8==6.0.0
+flake8==7.0.0
     # via -r requirements/dev/dev.in
-google-auth==1.26.1
+google-auth==2.29.0
     # via kubernetes
 html5lib==1.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-identify==1.5.13
+identify==2.5.36
     # via pre-commit
 idna==2.10
     # via
     #   -c requirements/dev/../base/base.txt
     #   anyio
+    #   httpx
     #   requests
-    #   yarl
-importlib-metadata==5.0.0
+importlib-metadata==7.1.0
     # via -r requirements/dev/dev.in
 importlib-resources==6.4.0
     # via kubernetes-validate
 inflection==0.5.1
     # via pytest-factoryboy
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-invoke==1.5.0
+invoke==2.2.0
     # via invoke-kubesae
 invoke-kubesae==0.1.0
     # via -r requirements/dev/dev.in
-ipykernel==5.4.3
-    # via notebook
-ipython==7.20.0
+ipykernel==6.29.4
+    # via
+    #   jupyterlab
+    #   nbclassic
+    #   notebook
+ipython==8.24.0
     # via
     #   -r requirements/dev/dev.in
     #   ipykernel
     #   jupyterlab
 ipython-genutils==0.2.0
     # via
-    #   jupyter-server
-    #   nbformat
+    #   nbclassic
     #   notebook
-    #   traitlets
-isort==5.7.0
+isort==5.13.2
     # via -r requirements/dev/dev.in
-jedi==0.18.0
-    # via ipython
+jedi==0.19.1
+    # via
+    #   ipython
+    #   pudb
 jinja2==3.0.3
     # via
     #   -r requirements/dev/dev.in
@@ -208,6 +227,7 @@ jinja2==3.0.3
     #   jupyter-server
     #   jupyterlab
     #   jupyterlab-server
+    #   nbclassic
     #   nbconvert
     #   notebook
 jmespath==0.10.0
@@ -216,37 +236,44 @@ jmespath==0.10.0
     #   awslogs
     #   boto3
     #   botocore
-json5==0.9.5
+json5==0.9.25
     # via jupyterlab-server
-jsonschema==3.2.0
+jsonschema==4.22.0
     # via
     #   jupyterlab-server
     #   kubernetes-validate
     #   nbformat
-jupyter-client==6.1.11
+jsonschema-specifications==2023.12.1
+    # via jsonschema
+jupyter-client==7.2.0
     # via
     #   ipykernel
     #   jupyter-server
+    #   nbclassic
     #   nbclient
     #   notebook
-jupyter-core==4.7.1
+jupyter-core==5.7.2
     # via
+    #   ipykernel
     #   jupyter-client
     #   jupyter-server
     #   jupyterlab
+    #   nbclassic
+    #   nbclient
     #   nbconvert
     #   nbformat
     #   notebook
-jupyter-server==1.3.0
+jupyter-server==1.24.0
     # via
     #   jupyterlab
     #   jupyterlab-server
     #   nbclassic
-jupyterlab==3.0.7
+    #   notebook-shim
+jupyterlab==3.5.3
     # via -r requirements/dev/dev.in
-jupyterlab-pygments==0.1.2
+jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.2.1
+jupyterlab-server==2.16.3
     # via jupyterlab
 kubernetes==12.0.0
     # via
@@ -258,36 +285,52 @@ l18n==2020.6.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-markupsafe==2.1.1
-    # via jinja2
+markupsafe==2.1.5
+    # via
+    #   jinja2
+    #   nbconvert
+matplotlib-inline==0.1.7
+    # via
+    #   ipykernel
+    #   ipython
 mccabe==0.7.0
     # via flake8
-mistune==0.8.4
+mistune==3.0.2
     # via nbconvert
-multidict==6.0.5
-    # via yarl
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
-nbclassic==0.2.6
-    # via jupyterlab
-nbclient==0.5.2
-    # via nbconvert
-nbconvert==6.0.7
+nbclassic==1.0.0
     # via
-    #   jupyter-server
+    #   jupyterlab
     #   notebook
-nbformat==5.1.2
+nbclient==0.10.0
+    # via nbconvert
+nbconvert==7.16.4
     # via
     #   jupyter-server
+    #   nbclassic
+    #   notebook
+nbformat==5.10.4
+    # via
+    #   jupyter-server
+    #   nbclassic
     #   nbclient
     #   nbconvert
     #   notebook
-nest-asyncio==1.5.1
-    # via nbclient
-nodeenv==1.5.0
+nest-asyncio==1.6.0
+    # via
+    #   ipykernel
+    #   jupyter-client
+    #   nbclassic
+    #   notebook
+nodeenv==1.8.0
     # via pre-commit
-notebook==6.2.0
-    # via nbclassic
+notebook==6.5.7
+    # via jupyterlab
+notebook-shim==0.2.4
+    # via
+    #   jupyterlab
+    #   nbclassic
 oauthlib==3.1.0
     # via
     #   -c requirements/dev/../base/base.txt
@@ -302,85 +345,86 @@ packaging==24.0
     # via
     #   ansible-core
     #   black
-    #   bleach
+    #   ipykernel
+    #   jupyter-server
     #   jupyterlab
     #   jupyterlab-server
     #   kubernetes-validate
+    #   nbconvert
+    #   pudb
     #   pytest
-pandocfilters==1.4.3
+    #   pytest-factoryboy
+pandocfilters==1.5.1
     # via nbconvert
-parso==0.8.1
+parso==0.8.4
     # via jedi
-pathspec==0.9.0
+pathspec==0.12.1
     # via black
-pexpect==4.8.0
-    # via ipython
-pickleshare==0.7.5
+pexpect==4.9.0
     # via ipython
 pillow==9.3.0
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-platformdirs==2.5.2
+platformdirs==4.2.2
     # via
     #   black
+    #   jupyter-core
     #   virtualenv
-pluggy==0.13.1
+pluggy==1.5.0
     # via pytest
-pre-commit==2.20.0
+pre-commit==3.7.1
     # via -r requirements/dev/dev.in
-prometheus-client==0.9.0
+prometheus-client==0.20.0
     # via
     #   jupyter-server
+    #   nbclassic
     #   notebook
-prompt-toolkit==3.0.16
+prompt-toolkit==3.0.43
     # via ipython
+psutil==5.9.8
+    # via ipykernel
 ptyprocess==0.7.0
     # via
     #   pexpect
     #   terminado
-pudb==2020.1
+pudb==2024.1
     # via -r requirements/dev/dev.in
-py==1.10.0
-    # via pytest
-pyasn1==0.4.8
+pure-eval==0.2.2
+    # via stack-data
+pyasn1==0.6.0
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.2.8
+pyasn1-modules==0.4.0
     # via google-auth
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
 pycparser==2.20
     # via
     #   -c requirements/dev/../base/base.txt
     #   cffi
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
-pygments==2.8.0
+pygments==2.18.0
     # via
     #   ipython
-    #   jupyterlab-pygments
     #   nbconvert
     #   pudb
-pyrsistent==0.17.3
-    # via
-    #   jsonschema
-    #   referencing
-pytest==7.1.3
+pytest==8.2.1
     # via
     #   -r requirements/dev/dev.in
     #   pytest-cov
     #   pytest-django
     #   pytest-factoryboy
     #   pytest-mock
-pytest-cov==2.11.1
+pytest-cov==5.0.0
     # via -r requirements/dev/dev.in
-pytest-django==4.1.0
+pytest-django==4.8.0
     # via -r requirements/dev/dev.in
-pytest-factoryboy==2.1.0
+pytest-factoryboy==2.7.0
     # via -r requirements/dev/dev.in
-pytest-mock==3.5.1
+pytest-mock==3.14.0
     # via -r requirements/dev/dev.in
 python-dateutil==2.8.1
     # via
@@ -395,7 +439,6 @@ python-string-utils==1.0.0
 pytz==2021.1
     # via
     #   -c requirements/dev/../base/base.txt
-    #   babel
     #   django
     #   django-modelcluster
     #   l18n
@@ -408,13 +451,18 @@ pyyaml==6.0.1
     #   kubernetes
     #   kubernetes-validate
     #   pre-commit
-pyzmq==22.0.3
+pyzmq==26.0.3
     # via
+    #   ipykernel
     #   jupyter-client
     #   jupyter-server
+    #   nbclassic
     #   notebook
-referencing==0.8.11
-    # via kubernetes-validate
+referencing==0.35.1
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+    #   kubernetes-validate
 requests==2.25.1
     # via
     #   -c requirements/dev/../base/base.txt
@@ -426,9 +474,13 @@ requests-oauthlib==1.3.0
     # via
     #   -c requirements/dev/../base/base.txt
     #   kubernetes
-resolvelib==0.5.4
+resolvelib==1.0.1
     # via ansible-core
-rsa==4.5
+rpds-py==0.18.1
+    # via
+    #   jsonschema
+    #   referencing
+rsa==4.7.2
     # via
     #   awscli
     #   google-auth
@@ -437,25 +489,25 @@ s3transfer==0.10.1
     #   -c requirements/dev/../base/base.txt
     #   awscli
     #   boto3
-send2trash==1.5.0
+send2trash==1.8.3
     # via
     #   jupyter-server
+    #   nbclassic
     #   notebook
 six==1.15.0
     # via
     #   -c requirements/dev/../base/base.txt
-    #   argon2-cffi
+    #   asttokens
     #   bleach
-    #   google-auth
     #   html5lib
-    #   jsonschema
     #   kubernetes
     #   l18n
     #   openshift
     #   python-dateutil
-    #   websocket-client
-sniffio==1.2.0
-    # via anyio
+sniffio==1.3.1
+    # via
+    #   anyio
+    #   httpx
 soupsieve==2.2
     # via
     #   -c requirements/dev/../base/base.txt
@@ -465,39 +517,46 @@ sqlparse==0.4.1
     #   -c requirements/dev/../base/base.txt
     #   django
     #   django-debug-toolbar
+stack-data==0.6.3
+    # via ipython
 telepath==0.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-termcolor==1.1.0
+termcolor==2.4.0
     # via awslogs
-terminado==0.9.2
+terminado==0.18.1
     # via
     #   jupyter-server
+    #   nbclassic
     #   notebook
-testpath==0.4.4
+tinycss2==1.3.0
     # via nbconvert
-toml==0.10.2
-    # via pre-commit
 tomli==2.0.1
     # via
     #   black
+    #   coverage
+    #   jupyterlab
     #   pytest
-tornado==6.1
+tornado==6.4
     # via
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
     #   jupyterlab
+    #   nbclassic
     #   notebook
     #   terminado
-traitlets==5.0.5
+traitlets==5.14.3
     # via
+    #   comm
     #   ipykernel
     #   ipython
     #   jupyter-client
     #   jupyter-core
     #   jupyter-server
+    #   matplotlib-inline
+    #   nbclassic
     #   nbclient
     #   nbconvert
     #   nbformat
@@ -505,39 +564,49 @@ traitlets==5.0.5
 typing-extensions==4.11.0
     # via
     #   black
+    #   ipython
     #   kubernetes-validate
+    #   pytest-factoryboy
+    #   urwid
 urllib3==1.26.4
     # via
     #   -c requirements/dev/../base/base.txt
     #   botocore
     #   kubernetes
     #   requests
-urwid==2.1.2
+urwid==2.6.12
+    # via
+    #   pudb
+    #   urwid-readline
+urwid-readline==0.14
     # via pudb
-virtualenv==20.17.1
+virtualenv==20.26.2
     # via pre-commit
 wagtail==4.2.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail-factories
-wagtail-factories==2.0.1
+wagtail-factories==4.1.0
     # via -r requirements/dev/dev.in
-wcwidth==0.2.5
-    # via prompt-toolkit
+wcwidth==0.2.13
+    # via
+    #   prompt-toolkit
+    #   urwid
 webencodings==0.5.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   bleach
     #   html5lib
-websocket-client==0.57.0
-    # via kubernetes
+    #   tinycss2
+websocket-client==1.8.0
+    # via
+    #   jupyter-server
+    #   kubernetes
 willow==1.4
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-yarl==1.9.4
-    # via referencing
-zipp==3.4.0
+zipp==3.18.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --output-file=requirements/dev/dev.txt requirements/dev/dev.in
 #
-ansible==7.6.0
+ansible==9.5.1
     # via
     #   -r requirements/dev/dev.in
     #   invoke-kubesae
-ansible-core==2.14.6
+ansible-core==2.16.6
     # via ansible
 anyascii==0.1.7
     # via
@@ -30,7 +30,8 @@ attrs==20.3.0
     # via
     #   jsonschema
     #   pytest
-awscli==1.29.4
+    #   referencing
+awscli==1.32.104
     # via -r requirements/dev/dev.in
 awslogs==0.14.0
     # via -r requirements/dev/dev.in
@@ -42,16 +43,16 @@ beautifulsoup4==4.8.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-black==22.6.0
+black==24.4.2
     # via -r requirements/dev/dev.in
 bleach==3.3.0
     # via nbconvert
-boto3==1.28.4
+boto3==1.34.104
     # via
     #   -c requirements/dev/../base/base.txt
     #   awslogs
     #   invoke-kubesae
-botocore==1.31.4
+botocore==1.34.104
     # via
     #   -c requirements/dev/../base/base.txt
     #   awscli
@@ -170,8 +171,11 @@ idna==2.10
     #   -c requirements/dev/../base/base.txt
     #   anyio
     #   requests
+    #   yarl
 importlib-metadata==5.0.0
     # via -r requirements/dev/dev.in
+importlib-resources==6.4.0
+    # via kubernetes-validate
 inflection==0.5.1
     # via pytest-factoryboy
 iniconfig==1.1.1
@@ -206,7 +210,6 @@ jinja2==3.0.3
     #   jupyterlab-server
     #   nbconvert
     #   notebook
-    #   openshift
 jmespath==0.10.0
     # via
     #   -c requirements/dev/../base/base.txt
@@ -249,7 +252,7 @@ kubernetes==12.0.0
     # via
     #   -r requirements/dev/dev.in
     #   openshift
-kubernetes-validate==1.25.2
+kubernetes-validate==1.29.1
     # via -r requirements/dev/dev.in
 l18n==2020.6.1
     # via
@@ -261,6 +264,8 @@ mccabe==0.7.0
     # via flake8
 mistune==0.8.4
     # via nbconvert
+multidict==6.0.5
+    # via yarl
 mypy-extensions==0.4.3
     # via black
 nbclassic==0.2.6
@@ -291,14 +296,16 @@ openpyxl==3.1.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
-openshift==0.12.0
+openshift==0.13.2
     # via -r requirements/dev/dev.in
-packaging==20.9
+packaging==24.0
     # via
     #   ansible-core
+    #   black
     #   bleach
     #   jupyterlab
     #   jupyterlab-server
+    #   kubernetes-validate
     #   pytest
 pandocfilters==1.4.3
     # via nbconvert
@@ -356,10 +363,10 @@ pygments==2.8.0
     #   jupyterlab-pygments
     #   nbconvert
     #   pudb
-pyparsing==2.4.7
-    # via packaging
 pyrsistent==0.17.3
-    # via jsonschema
+    # via
+    #   jsonschema
+    #   referencing
 pytest==7.1.3
     # via
     #   -r requirements/dev/dev.in
@@ -406,6 +413,8 @@ pyzmq==22.0.3
     #   jupyter-client
     #   jupyter-server
     #   notebook
+referencing==0.8.11
+    # via kubernetes-validate
 requests==2.25.1
     # via
     #   -c requirements/dev/../base/base.txt
@@ -423,9 +432,7 @@ rsa==4.5
     # via
     #   awscli
     #   google-auth
-ruamel-yaml==0.16.12
-    # via openshift
-s3transfer==0.6.1
+s3transfer==0.10.1
     # via
     #   -c requirements/dev/../base/base.txt
     #   awscli
@@ -495,6 +502,10 @@ traitlets==5.0.5
     #   nbconvert
     #   nbformat
     #   notebook
+typing-extensions==4.11.0
+    # via
+    #   black
+    #   kubernetes-validate
 urllib3==1.26.4
     # via
     #   -c requirements/dev/../base/base.txt
@@ -524,6 +535,8 @@ willow==1.4
     # via
     #   -c requirements/dev/../base/base.txt
     #   wagtail
+yarl==1.9.4
+    # via referencing
 zipp==3.4.0
     # via importlib-metadata
 


### PR DESCRIPTION
This PR serves as documentation/reference for the Kubernetes upgrade of the `Philly Hip` cluster. The sites on this cluster are all the [staging](https://hip-staging.phila.gov/) and [production](https://hip.phila.gov/).

**Ingress Nginx**
```
> helm -n ingress-nginx list                                    
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ingress-nginx   ingress-nginx   7               2024-05-14 10:21:08.299385 -0400 EDT    deployed        ingress-nginx-4.9.1     1.9.6
```

**Cert Manager**
```
>  helm -n cert-manager list                                    
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    6               2024-05-13 14:39:06.888402 -0400 EDT    deployed        cert-manager-v1.14.3    v1.14.3
```

**AWS Fluent Bit**
Installing the updated version required running `kubectl -n kube-system get secret | grep fluent` to list secrets. Then `kubectl -n kube-system delete secret sh.helm.release.v1.aws-for-fluent-bit.v1` to delete the old secret. Finally, running the playbook with the updated version.
```
 > helm -n kube-system list          
NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION     
aws-for-fluent-bit      kube-system     1               2024-05-20 13:25:21.358038 -0400 EDT    deployed        aws-for-fluent-bit-0.1.32       2.31.12.20231011  
```


**Cloudwatch Metrics**
```
> helm -n amazon-cloudwatch list
NAME                    NAMESPACE               REVISION        UPDATED                                 STATUS          CHART                           APP VERSION   
aws-cloudwatch-metrics  amazon-cloudwatch       2               2024-05-14 10:30:13.814141 -0400 EDT    deployed        aws-cloudwatch-metrics-0.0.11   1.300032.2b361
```

**Descheduler Version**
```
name: descheduler
              app.kubernetes.io/instance: descheduler
              app.kubernetes.io/name: descheduler
            name: descheduler
              - /bin/descheduler
              image: registry.k8s.io/descheduler/descheduler:v0.29.0
              name: descheduler
            serviceAccount: descheduler
            serviceAccountName: descheduler
```
**Cluster and pods version** 

![Screenshot 2024-05-14 at 1 47 35 PM](https://github.com/caktus/philly-hip/assets/87770895/3ac286fa-64ef-4635-9c40-45e3ccd0dd15)

**Notes:** 
 - I could not update `k8s_aws_fluent_bit_chart_version` - It threw an error.


**Closes**
 - https://app.clickup.com/t/8687f7bgp
