### PR TITLE
Run tests in GH runner and pin django-compressor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on:
+      - self-hosted
+      - philly-hip
     env:
       DJANGO_SETTINGS_MODULE: hip.settings.dev
     services:

--- a/deploy/deploy-runner.yml
+++ b/deploy/deploy-runner.yml
@@ -39,6 +39,7 @@
           - gnupg
           - lsb-release
           - libpq-dev
+          - libffi-dev
           - python3.10
           - python3.10-dev
     - name: Add Docker's official GPG key

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -7,7 +7,7 @@ django_model_utils
 dj-database-url
 django-model-utils
 django-storages
-django-compressor
+django-compressor==4.5.1
 django-taggit
 django-ipware
 django-import-export
@@ -35,4 +35,6 @@ wagtail
 wagtailfontawesome
 wagtailmenus
 
+# Delete once deploy is successful
 cffi==1.17.0
+rcssmin==1.1.2


### PR DESCRIPTION
After merging number #282 the deployment stopped working. This is because only certain IPs have access to the application (per the client's request), see which IPs have access [here](https://github.com/caktus/philly-hip/blob/f3f9832a3841a06f48b664555b524806c8dc8855/deploy/group_vars/all.yml#L20-L25). To fix tests and deployments, we created a Github runner in that same PR #282. 

This PR enables tests to run in that runner, thus enabling tests & deploys to work again.