### PR TITLE
Update New Relic and Container Instance Size

### DIFF
--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -58,8 +58,8 @@ cloudformation_stack:
 
   template_parameters:
     UseAES256Encryption: "true"
-    AdministratorIPAddress: "{{ administrator_ip_cidrs[0] }}"  # Stack allows only single IP here to SSH to bastion
-    BastionAMI: "ami-0ad554caf874569d2" # https://cloud-images.ubuntu.com/locator/ec2/ [us-east-1 amd64]
+    AdministratorIPAddress: ""  # Stack allows only single IP here to SSH to bastion
+    BastionAMI: "" # https://cloud-images.ubuntu.com/locator/ec2/ [us-east-1 amd64]
     BastionKeyName: rluna_hip
     BastionInstanceType: t3.small # Is this a proper size?
     BastionType: SSH
@@ -68,9 +68,9 @@ cloudformation_stack:
     DomainNameAlternates: ""
     PrimaryAZ: "{{ aws_region }}a"
     SecondaryAZ: "{{ aws_region }}b"
-    DesiredScale: 2
+    DesiredScale: 3
     MaxScale: 4
-    ContainerInstanceType: t3a.medium
+    ContainerInstanceType: t3a.large
     AssetsBucketAccessControl: Private
     AssetsUseCloudFront: "false"
     DatabaseClass: db.t3.small

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -58,8 +58,8 @@ cloudformation_stack:
 
   template_parameters:
     UseAES256Encryption: "true"
-    AdministratorIPAddress: ""  # Stack allows only single IP here to SSH to bastion
-    BastionAMI: "" # https://cloud-images.ubuntu.com/locator/ec2/ [us-east-1 amd64]
+    AdministratorIPAddress: "{{ administrator_ip_cidrs[0] }}"  # Stack allows only single IP here to SSH to bastion
+    BastionAMI: "ami-0ad554caf874569d2" # https://cloud-images.ubuntu.com/locator/ec2/ [us-east-1 amd64]
     BastionKeyName: rluna_hip
     BastionInstanceType: t3.small # Is this a proper size?
     BastionType: SSH

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -1,6 +1,7 @@
 ---
 - src: https://github.com/caktus/ansible-role-aws-web-stacks
   name: caktus.aws-web-stacks
+  version: v0.3.0
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
   version: v1.7.0
   name: caktus.k8s-web-cluster

--- a/requirements/deploy/deploy.in
+++ b/requirements/deploy/deploy.in
@@ -2,5 +2,5 @@
 -c ../base/base.txt
 
 pymemcache
-newrelic
+newrelic==10.4.0
 uwsgi==2.0.26 # Pinned version to work with Python 3.11

--- a/requirements/deploy/deploy.txt
+++ b/requirements/deploy/deploy.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/deploy/deploy.txt requirements/deploy/deploy.in
 #
-newrelic==6.0.1.155
+newrelic==10.4.0
     # via -r requirements/deploy/deploy.in
 pymemcache==3.4.4
     # via -r requirements/deploy/deploy.in


### PR DESCRIPTION
This PR updates the container Instance size and New Relic to avoid the following error 

```
kubectl -n hip-staging logs -lapp=app

  File "/usr/local/lib/python3.11/site-packages/newrelic/packages/wrapt/__init__.py", line 10, in <module>
    from .decorators import (adapter_factory, AdapterFactory, decorator,
  File "/usr/local/lib/python3.11/site-packages/newrelic/packages/wrapt/decorators.py", line 34, in <module>
    from inspect import ismethod, isclass, formatargspec
ImportError: cannot import name 'formatargspec' from 'inspect' (/usr/local/lib/python3.11/inspect.py)
```