### PR TITLE
Update Ingress Nginx Chart

### DIFF
--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -95,8 +95,8 @@ cloudformation_stack:
 k8s_cluster_type: aws
 # aws eks describe-cluster --name=philly-hip-stack-cluster --query 'cluster.arn'
 k8s_context: "arn:aws:eks:us-east-1:061553509755:cluster/{{ cluster_name }}"
-k8s_ingress_nginx_chart_version: "4.11.3"
-k8s_cert_manager_chart_version: "v1.16.2"
+k8s_ingress_nginx_chart_version: "4.11.5"
+k8s_cert_manager_chart_version: "v1.17.1"
 k8s_letsencrypt_email: admin@caktusgroup.com
 k8s_iam_users: [noop]  # https://github.com/caktus/ansible-role-k8s-web-cluster/issues/17
 # aws-for-fluent-bit


### PR DESCRIPTION
Some people at Wiz wrote a great post about this: https://www.wiz.io/blog/ingress-nginx-kubernetes-vulnerabilities

_Ingress Nginx version update (and other packages)_

**Ingress Nginx**
```sh
> helm -n ingress-nginx list 
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ingress-nginx   ingress-nginx   10              2025-03-26 10:11:05.698095 -0400 EDT    deployed        ingress-nginx-4.11.5    1.11.5  
```

**Cert Manager**
```sh
> helm -n cert-manager list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    8               2025-03-26 10:12:28.163548 -0400 EDT    deployed        cert-manager-v1.17.1    v1.17.1   
```

_Ensure the admission webhook endpoint is not exposed externally_ 

```
> kubectl get svc -n hip-production            
NAME        TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
app         ClusterIP   172.20.211.185   <none>        8000/TCP    3y351d
memcached   ClusterIP   172.20.157.96    <none>        11211/TCP   3y351d

> kubectl get svc -n hip-staging             
NAME        TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
app         ClusterIP   172.20.53.98     <none>        8000/TCP    3y351d
memcached   ClusterIP   172.20.213.170   <none>        11211/TCP   3y351d
```
Philly Hip svc is of type ClusterIP. ClusterIP services are only accessible from within the cluster, you cannot directly curl it from outside. More on that [here](https://www.linkedin.com/pulse/clusterip-service-kubernetes-christopher-adamson-jvy3c#:~:text=When%20you%20create%20a%20ClusterIP,cannot%20be%20reached%20from%20outside.).


Closes:
 - https://app.clickup.com/t/868d817yf