### PR TITLE
Deploy GitHub runner with `repo` and `org:admin` scoped PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,22 +294,3 @@ To reset your local database from a deployed environment:
 As mentioned in the Database setup instructions, you may need to visit 
 [/cms/sites](http://localhost:8000/cms/sites/) and change the first entry's 
 `Hostname` field to `localhost` to enable page previews in the Wagtail admin.
-
-### GitHub Actions Runner
-
-There are [GitHub Actions self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners) deployed in the Kubernetes cluster along side the application.
-
-Setup instructions:
-
-* Obtain a [GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the `repo` scope that's valid for one week (it needs to be active only for the initial deployment). Add this to a local environment variable `RUNNER_CFG_PAT`:
-
-```sh
-export RUNNER_CFG_PAT="gh......"
-```
-
-* Run the playbook to deploy the runner:
-
-```sh
-cd deploy/
-ansible-playbook deploy-runner.yml
-```

--- a/deploy/deploy-runner.yml
+++ b/deploy/deploy-runner.yml
@@ -5,7 +5,7 @@
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"
     runner_namespace: github-runner
-    chart_version: "0.9.3"
+    chart_version: "0.11.0"
   gather_facts: false
   tasks:
     # https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/quickstart-for-actions-runner-controller

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -198,3 +198,22 @@ To see configured ansible variable like ``k8s_environment_variables`` you can us
 
 There are many other useful commands built into `invoke-kubesae` itself, so check out
 its [documentation](https://github.com/caktus/invoke-kubesae).
+
+# GitHub Actions Runner
+
+There are [GitHub Actions self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners) deployed in the Kubernetes cluster along side the application.
+
+Setup instructions:
+
+* Obtain a [GitHub PAT](https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#list-self-hosted-runners-for-an-organization) with the `repo` and `org:admin` scope that's valid for one week (it needs to be active only for the initial deployment). Add this to a local environment variable `RUNNER_CFG_PAT`:
+
+```sh
+export RUNNER_CFG_PAT="gh......"
+```
+
+* Run the playbook to deploy the runner:
+
+```sh
+cd deploy/
+ansible-playbook deploy-runner.yml
+```


### PR DESCRIPTION
The GitHub runner needs two scopes to run: `repo` and `org:admin`.

```
> kubectl -n github-runner get pod                        
NAME                                     READY   STATUS    RESTARTS   AGE
arc-gha-rs-controller-5fd5c6b567-9p944   1/1     Running   0          8m18s
arc-runner-set-f577755c-listener         1/1     Running   0          8m10s
```

### Investigation

Error message in controller pod:

```
2025-06-10T14:31:28Z    ERROR   Reconciler error        {"controller": "autoscalingrunnerset", "controllerGroup": "actions.github.com", "controllerKind": "AutoscalingRunnerSet", "AutoscalingRunnerSet": {"name":"arc-runner-set","namespace":"github-runner"}, "namespace": "github-runner", "name": "arc-runner-set", "reconcileID": "f4c8328b-81fd-4c6b-88a7-598e36a95fc5", "error": "failed to get runner registration token on refresh: github api error: StatusCode 403, RequestID \"7F11:31B968:196DEEA:32FD843:684841BD\": {\"message\":\"Must have admin rights to Repository.\",\"documentation_url\":\"https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository\",\"status\":\"403\"}"}
```

"Must have admin rights to Repository" and the [link](https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#list-self-hosted-runners-for-an-organization) provided the context to get it running.