### PR TITLE
Upgrade the Base OS Image and Kubernetes to 1.33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   openssh-client -- for git over SSH
 #   sudo -- to run commands as superuser
 #   vim -- enhanced vi editor for commits
-ENV KUBE_CLIENT_VERSION="v1.32.6"
+ENV KUBE_CLIENT_VERSION="v1.33.0"
 ENV HELM_VERSION="3.18.3"
 ENV POSTGRESQL_CLIENT_VERSION="15"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \

--- a/deploy/deploy-cf-stack.yml
+++ b/deploy/deploy-cf-stack.yml
@@ -4,6 +4,11 @@
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"
+    environment:
+      AWS_ACCESS_KEY_ID: ""
+      AWS_SECRET_ACCESS_KEY: ""
+      AWS_SESSION_TOKEN: ""
+      AWS_SECURITY_TOKEN: ""
   gather_facts: false
   roles:
     - role: caktus.aws-web-stacks

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -64,6 +64,8 @@ cloudformation_stack:
     AdministratorIPAddress: "{{ administrator_ip_cidrs[0] }}"  # Stack allows only single IP here to SSH to bastion
     BastionAMI: "ami-0ad554caf874569d2" # https://cloud-images.ubuntu.com/locator/ec2/ [us-east-1 amd64]
     BastionKeyName: rluna_hip
+    CustomEKSAMI: "" # Optional when CustomAMIImageType is set. Preferrably do not set as AWS will select best optimized image if CustomAMIImageType is set.
+    CustomAMIImageType: AL2023_x86_64_STANDARD
     BastionInstanceType: t3.small # Is this a proper size?
     BastionType: SSH
     CustomerManagedCmkArn: ""
@@ -95,8 +97,8 @@ cloudformation_stack:
 k8s_cluster_type: aws
 # aws eks describe-cluster --name=philly-hip-stack-cluster --query 'cluster.arn'
 k8s_context: "arn:aws:eks:us-east-1:061553509755:cluster/{{ cluster_name }}"
-k8s_ingress_nginx_chart_version: "4.12.3"
-k8s_cert_manager_chart_version: "v1.17.2"
+k8s_ingress_nginx_chart_version: "4.13.0"
+k8s_cert_manager_chart_version: "v1.18"
 k8s_letsencrypt_email: admin@caktusgroup.com
 k8s_iam_users: [noop]  # https://github.com/caktus/ansible-role-k8s-web-cluster/issues/17
 # aws-for-fluent-bit
@@ -223,7 +225,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.32.2
+k8s_descheduler_chart_version: v0.33.0
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:

--- a/deploy/stack/eks-nat.yml
+++ b/deploy/stack/eks-nat.yml
@@ -71,6 +71,14 @@ Conditions:
     - !Equals
       - !Ref 'DatabaseReplication'
       - 'true'
+  UseCustomAMI: !Not
+    - !Equals
+      - !Ref 'CustomEKSAMI'
+      - ''
+  UseCustomAMIType: !Not
+    - !Equals
+      - !Ref 'CustomAMIImageType'
+      - ''
   EitherCacheCondition: !Or
     - !Condition 'UsingMemcached'
     - !Condition 'UsingRedis'
@@ -234,6 +242,15 @@ Metadata:
           - EnableEksEncryptionConfig
           - EksPublicAccessCidrs
           - EksClusterName
+          - CustomEKSAMI
+          - CustomAMIImageType
+          - EksClusterVersion
+      - Label:
+          default: Elastic Kubernetes Service (EKS)
+        Parameters:
+          - EnableEksEncryptionConfig
+          - EksPublicAccessCidrs
+          - EksClusterName
       - Label:
           default: Bastion Server
         Parameters:
@@ -266,6 +283,10 @@ Metadata:
         default: Instance Type
       ContainerVolumeSize:
         default: Root Volume Size
+      CustomAMIImageType:
+        default: Custom AMI Image Type
+      CustomEKSAMI:
+        default: Custom EKS AMI
       CustomerManagedCmkArn:
         default: Customer managed key ARN
       DatabaseAllocatedStorage:
@@ -786,6 +807,14 @@ Parameters:
     Default: '20'
     Description: Size of instance EBS root volume (in GB)
     Type: Number
+  CustomAMIImageType:
+    Default: ''
+    Description: The image type to match the custom AMI. E.g., AL2023_x86_64_STANDARD, AL2_x86_64
+    Type: String
+  CustomEKSAMI:
+    Default: ''
+    Description: Custom AMI ID for EKS node group
+    Type: String
   CustomerManagedCmkArn:
     Default: ''
     Description: KMS CMK ARN to encrypt stack resources (except for public buckets).
@@ -1954,9 +1983,14 @@ Resources:
     DependsOn:
       - EksCluster
     Properties:
+      AmiType: !If
+        - UseCustomAMIType
+        - !Ref 'CustomAMIImageType'
+        - !Ref 'AWS::NoValue'
       ClusterName: !Ref 'EksCluster'
       LaunchTemplate:
         Id: !Ref 'NodegroupLaunchTemplate'
+        Version: !GetAtt 'NodegroupLaunchTemplate.LatestVersionNumber'
       NodeRole: !GetAtt 'ContainerInstanceRole.Arn'
       ScalingConfig:
         DesiredSize: !Ref 'DesiredScale'
@@ -1981,7 +2015,11 @@ Resources:
                 - !Ref 'CustomerManagedCmkArn'
                 - !Ref 'AWS::NoValue'
               VolumeSize: !Ref 'ContainerVolumeSize'
-              VolumeType: gp2
+              VolumeType: gp3
+        ImageId: !If
+          - UseCustomAMI
+          - !Ref 'CustomEKSAMI'
+          - !Ref 'AWS::NoValue'
         InstanceType: !Ref 'ContainerInstanceType'
         MetadataOptions:
           HttpPutResponseHopLimit: 3

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -116,7 +116,6 @@ libsass==0.23.0
     # via -r requirements/base/base.in
 oauthlib==3.3.1
     # via
-    #   -r requirements/base/base.in
     #   requests-oauthlib
     #   social-auth-core
 openpyxl==3.1.2
@@ -192,7 +191,9 @@ wagtailmenus==4.0.2
 whitenoise==5.2.0
     # via -r requirements/base/base.in
 willow[heif]==1.10.0
-    # via wagtail
+    # via
+    #   wagtail
+    #   willow
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/deploy/deploy.txt
+++ b/requirements/deploy/deploy.txt
@@ -10,7 +10,7 @@ pymemcache==3.4.4
     # via -r requirements/deploy/deploy.in
 six==1.15.0
     # via
-    #   -c requirements/deploy/../base/base.txt
+    #   -c requirements/base/base.txt
     #   pymemcache
 uwsgi==2.0.26
     # via -r requirements/deploy/deploy.in

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -16,7 +16,7 @@ awslogs
 Jinja2==3.1.6
 openshift==0.13.2
 kubernetes==32.0.1
-kubernetes-validate~=1.32.0
+kubernetes-validate~=1.33.0
 
 pre-commit
 coverage

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -12,7 +12,7 @@ ansible-core==2.17.2
     # via ansible
 anyascii==0.1.7
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 anyio==3.7.1
     # via jupyter-server
@@ -29,7 +29,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 asgiref==3.8.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   django
 asttokens==2.4.1
     # via stack-data
@@ -45,7 +45,7 @@ babel==2.15.0
     # via jupyterlab-server
 beautifulsoup4==4.8.2
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   nbconvert
     #   wagtail
 black==24.4.2
@@ -54,12 +54,12 @@ bleach==6.1.0
     # via nbconvert
 boto3==1.39.2
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   awslogs
     #   invoke-kubesae
 botocore==1.39.2
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   awscli
     #   boto3
     #   s3transfer
@@ -67,19 +67,19 @@ cachetools==5.3.3
     # via google-auth
 certifi==2020.12.5
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   kubernetes
     #   requests
 cffi==1.17.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   argon2-cffi-bindings
     #   cryptography
 cfgv==3.4.0
     # via pre-commit
 chardet==4.0.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   requests
 click==8.1.7
     # via black
@@ -95,7 +95,7 @@ coverage[toml]==7.8.2
     #   pytest-cov
 cryptography==3.4.7
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   ansible-core
 debugpy==1.8.1
     # via ipykernel
@@ -103,14 +103,14 @@ decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   nbconvert
     #   willow
 distlib==0.3.8
     # via virtualenv
 django==5.2.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   django-debug-toolbar
     #   django-filter
     #   django-modelcluster
@@ -126,41 +126,41 @@ django-debug-toolbar==4.3.0
     # via -r requirements/dev/dev.in
 django-filter==23.5
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 django-modelcluster==6.3
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 django-permissionedforms==0.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 django-stubs-ext==5.2.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   django-tasks
 django-taggit==6.1.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 django-tasks==0.7.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 django-treebeard==4.5.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 djangorestframework==3.15.2
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 docutils==0.19
     # via awscli
 draftjs-exporter==2.1.7
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 durationpy==0.10
     # via kubernetes
@@ -168,7 +168,7 @@ entrypoints==0.4
     # via jupyter-client
 et-xmlfile==1.0.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   openpyxl
 executing==2.0.1
     # via stack-data
@@ -185,7 +185,7 @@ filelock==3.14.0
     # via virtualenv
 filetype==1.2.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   willow
 flake8==6.0.0
     # via -r requirements/dev/dev.in
@@ -195,7 +195,7 @@ identify==2.5.36
     # via pre-commit
 idna==2.10
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   anyio
     #   requests
 importlib-metadata==8.6.1
@@ -241,7 +241,7 @@ jinja2==3.1.6
     #   notebook
 jmespath==0.10.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   awslogs
     #   boto3
     #   botocore
@@ -288,11 +288,11 @@ kubernetes==32.0.1
     # via
     #   -r requirements/dev/dev.in
     #   openshift
-kubernetes-validate==1.32.0
+kubernetes-validate==1.33.1
     # via -r requirements/dev/dev.in
 laces==0.1.2
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 markupsafe==2.1.5
     # via
@@ -340,12 +340,12 @@ notebook-shim==0.2.4
     # via nbclassic
 oauthlib==3.3.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   kubernetes
     #   requests-oauthlib
 openpyxl==3.1.2
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 openshift==0.13.2
     # via -r requirements/dev/dev.in
@@ -372,12 +372,12 @@ pexpect==4.9.0
     # via ipython
 pillow==9.3.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   pillow-heif
     #   wagtail
 pillow-heif==0.15.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   willow
 platformdirs==4.2.2
     # via
@@ -415,7 +415,7 @@ pycodestyle==2.10.0
     # via flake8
 pycparser==2.20
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   cffi
 pyflakes==3.0.1
     # via flake8
@@ -441,7 +441,7 @@ pytest-mock==3.14.1
     # via -r requirements/dev/dev.in
 python-dateutil==2.8.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   awslogs
     #   botocore
     #   faker
@@ -451,11 +451,11 @@ python-string-utils==1.0.0
     # via openshift
 pytz==2024.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   django-modelcluster
 pyyaml==6.0.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   ansible-core
     #   awscli
     #   kubernetes
@@ -475,14 +475,14 @@ referencing==0.35.1
     #   kubernetes-validate
 requests==2.25.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   jupyterlab-server
     #   kubernetes
     #   requests-oauthlib
     #   wagtail
 requests-oauthlib==1.3.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   kubernetes
 resolvelib==1.0.1
     # via ansible-core
@@ -496,7 +496,7 @@ rsa==4.7.2
     #   google-auth
 s3transfer==0.13.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   awscli
     #   boto3
 send2trash==1.8.3
@@ -506,7 +506,7 @@ send2trash==1.8.3
     #   notebook
 six==1.15.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   asttokens
     #   bleach
     #   kubernetes
@@ -516,18 +516,18 @@ sniffio==1.3.1
     # via anyio
 soupsieve==2.2
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   beautifulsoup4
 sqlparse==0.4.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   django
     #   django-debug-toolbar
 stack-data==0.6.3
     # via ipython
 telepath==0.3.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
 termcolor==2.4.0
     # via awslogs
@@ -565,7 +565,7 @@ traitlets==5.14.3
     #   notebook
 typing-extensions==4.13.2
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   django-stubs-ext
     #   django-tasks
     #   ipython
@@ -574,7 +574,7 @@ typing-extensions==4.13.2
     #   urwid
 urllib3==1.26.4
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   botocore
     #   kubernetes
     #   requests
@@ -588,7 +588,7 @@ virtualenv==20.26.2
     # via pre-commit
 wagtail==7.0.1
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail-factories
 wagtail-factories==4.2.1
     # via -r requirements/dev/dev.in
@@ -606,8 +606,9 @@ websocket-client==1.8.0
     #   kubernetes
 willow[heif]==1.10.0
     # via
-    #   -c requirements/dev/../base/base.txt
+    #   -c requirements/base/base.txt
     #   wagtail
+    #   willow
 zipp==3.21.0
     # via importlib-metadata
 


### PR DESCRIPTION
This PR replaced the Amazon Linux Version 2 with Amazon Linux Version 2023 (AL2023) as the base linux image on the nodes in the EKS cluster and upgrades Kubernetes to version 1.33.


**Ingress Nginx**
```
> helm -n ingress-nginx list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ingress-nginx   ingress-nginx   2               2025-11-13 15:01:43.121062 -0500 EST    deployed        ingress-nginx-4.13.0    1.13.0   
```

**Cert Manager**
```
> helm -n cert-manager list                      
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    10              2025-11-13 15:02:56.950889 -0500 EST    deployed        cert-manager-v1.18.3    v1.18.3 
```

**Descheduler**
```
> helm -n kube-system list                      
NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION     
descheduler             kube-system     9               2025-11-13 15:01:30.151303 -0500 EST    deployed        descheduler-0.33.0              0.33.0  
```

**Cluster and pods version** 
<img width="1801" height="1012" alt="Screenshot 2025-11-13 at 3 54 27 PM" src="https://github.com/user-attachments/assets/bd9cdfb6-a859-484d-8c29-753b54493695" />



Closes:
 - https://app.clickup.com/t/868fwhzz9
