### PR TITLE
Update IP CIDRs

### DIFF
--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -19,9 +19,9 @@ k8s_namespace: "{{ app_name }}-{{ env_name }}"
 
 # IP addresses
 administrator_ip_cidrs:
-  - 70.62.97.170/32  # Caktus office
+  - 45.53.178.153/32  # Caktus office (Frontier)
   - 107.15.45.253/32  # Tobias
-  - 47.230.11.28/32  # Ronard
+  - 184.152.165.117/32  # Ronard
   - 107.223.185.195/32  # Colin
 
 # CloudFormation Outputs


### PR DESCRIPTION
In preparation for canceling Spectrum at the office, we are switching OpenVPN (Tunnelblick on Mac) to use the Frontier static IP for egress, this PR updates the Caktus IP.

**Note:** I tested this locally, I queried K8s to list all NSs and it worked. 


Closes:
 - https://github.com/orgs/caktus/projects/22/views/1?pane=issue&itemId=162196586&issue=caktus%7Cphilly-hip%7C323