### PR TITLE
Improve Embed and styling in site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       # https://github.com/marketplace/actions/slack-github-actions-slack-integration
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - 330-style-site-improvements
 
 jobs:
   build-push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - 330-style-site-improvements
 
 jobs:
   build-push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,12 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'requirements/*/**.txt'
       - name: Cache pre-commit
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/apps/disease_control/blocks.py
+++ b/apps/disease_control/blocks.py
@@ -1,0 +1,80 @@
+from wagtail import blocks
+
+
+class DescriptionBlock(blocks.RichTextBlock):
+    """Block for the disease/condition description."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("required", False)
+        super().__init__(*args, **kwargs)
+
+    class Meta:
+        label = "Description"
+        help_text = "Enter a short description which will be shown on the page listing diseases and conditions."
+
+
+class AtAGlanceBlock(blocks.RichTextBlock):
+    """Block for at a glance information."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("required", False)
+        super().__init__(*args, **kwargs)
+
+    class Meta:
+        label = "At a Glance"
+
+
+class CurrentRecommendationsBlock(blocks.RichTextBlock):
+    """Block for current recommendations."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("required", False)
+        super().__init__(*args, **kwargs)
+
+    class Meta:
+        label = "Current Recommendations"
+
+
+class SurveillanceBlock(blocks.RichTextBlock):
+    """Block for surveillance information."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("required", False)
+        super().__init__(*args, **kwargs)
+
+    class Meta:
+        label = "Surveillance"
+
+
+class VaccineInfoBlock(blocks.RichTextBlock):
+    """Block for vaccine information."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("required", False)
+        super().__init__(*args, **kwargs)
+
+    class Meta:
+        label = "Vaccine Info"
+
+
+class DiagnosisInfoBlock(blocks.RichTextBlock):
+    """Block for diagnosis and management information."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("required", False)
+        super().__init__(*args, **kwargs)
+
+    class Meta:
+        label = "Diagnosis & Management"
+
+
+class ProviderResourcesBlock(blocks.RichTextBlock):
+    """Block for healthcare provider resources."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("required", False)
+        super().__init__(*args, **kwargs)
+
+    class Meta:
+        label = "Provider Resources"
+        help_text = "List resources that will be useful for healthcare providers. Resources for patients and community will be pulled automatically by including any documents that are tagged with the title of this disease/condition."

--- a/apps/disease_control/migrations/0019_convert_disease_detail_to_streamfield.py
+++ b/apps/disease_control/migrations/0019_convert_disease_detail_to_streamfield.py
@@ -1,0 +1,171 @@
+# Generated manually to replace DiseaseAndConditionDetailPage content fields
+# with a StreamField, migrating both live DB rows AND Wagtail revision JSON.
+
+import uuid
+
+from django.db import migrations
+
+import wagtail.fields
+
+import apps.disease_control.models
+
+
+SECTION_FIELD_NAMES = (
+    "description",
+    "at_a_glance",
+    "current_recommendations",
+    "surveillance",
+    "vaccine_info",
+    "diagnosis_info",
+    "provider_resources",
+)
+
+
+def _stream_block(block_type, value):
+    return {
+        "type": block_type,
+        "value": str(value),
+        "id": str(uuid.uuid4()),
+    }
+
+
+def forwards(apps, schema_editor):
+    DiseaseAndConditionDetailPage = apps.get_model(
+        "disease_control", "DiseaseAndConditionDetailPage"
+    )
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Revision = apps.get_model("wagtailcore", "Revision")
+
+    # --- 1. Migrate live DB rows ---
+    for page in DiseaseAndConditionDetailPage.objects.all():
+        content_sections = []
+        for field_name in SECTION_FIELD_NAMES:
+            value = str(getattr(page, field_name) or "")
+            content_sections.append(_stream_block(field_name, value))
+
+        page.content_sections = content_sections
+        page.save(update_fields=["content_sections"])
+
+    # --- 2. Migrate Wagtail revisions ---
+    ct = ContentType.objects.get_for_model(DiseaseAndConditionDetailPage)
+    revisions = Revision.objects.filter(content_type=ct)
+
+    for revision in revisions:
+        content = revision.content
+
+        # Skip if already converted
+        if "content_sections" in content:
+            continue
+
+        # Check if any of the old field names exist
+        has_old_fields = any(field in content for field in SECTION_FIELD_NAMES)
+        if not has_old_fields:
+            continue
+
+        # Build the StreamField JSON from the old fields
+        content_sections = []
+        for field_name in SECTION_FIELD_NAMES:
+            value = content.pop(field_name, "") or ""
+            content_sections.append(_stream_block(field_name, str(value)))
+
+        content["content_sections"] = content_sections
+        revision.content = content
+        revision.save(update_fields=["content"])
+
+
+def backwards(apps, schema_editor):
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Revision = apps.get_model("wagtailcore", "Revision")
+    DiseaseAndConditionDetailPage = apps.get_model(
+        "disease_control", "DiseaseAndConditionDetailPage"
+    )
+
+    ct = ContentType.objects.get_for_model(DiseaseAndConditionDetailPage)
+    revisions = Revision.objects.filter(content_type=ct)
+
+    for revision in revisions:
+        content = revision.content
+
+        if "content_sections" not in content:
+            continue
+
+        # Restore old fields from the StreamField JSON
+        content_sections = content.pop("content_sections", [])
+        for block in content_sections:
+            block_type = block.get("type")
+            if block_type in SECTION_FIELD_NAMES:
+                content[block_type] = block.get("value", "")
+
+        revision.content = content
+        revision.save(update_fields=["content"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("disease_control", "0018_alter_diseasecontrolchildstaticpage_body"),
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("wagtailcore", "0094_alter_page_locale"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="diseaseandconditiondetailpage",
+            name="content_sections",
+            field=wagtail.fields.StreamField(
+                [
+                    ("description", 0),
+                    ("at_a_glance", 1),
+                    ("current_recommendations", 2),
+                    ("surveillance", 3),
+                    ("vaccine_info", 4),
+                    ("diagnosis_info", 5),
+                    ("provider_resources", 6),
+                ],
+                blank=True,
+                block_lookup={
+                    0: ("apps.disease_control.blocks.DescriptionBlock", (), {}),
+                    1: ("apps.disease_control.blocks.AtAGlanceBlock", (), {}),
+                    2: (
+                        "apps.disease_control.blocks.CurrentRecommendationsBlock",
+                        (),
+                        {},
+                    ),
+                    3: ("apps.disease_control.blocks.SurveillanceBlock", (), {}),
+                    4: ("apps.disease_control.blocks.VaccineInfoBlock", (), {}),
+                    5: ("apps.disease_control.blocks.DiagnosisInfoBlock", (), {}),
+                    6: ("apps.disease_control.blocks.ProviderResourcesBlock", (), {}),
+                },
+                default=apps.disease_control.models.default_disease_detail_content_sections,
+            ),
+        ),
+        migrations.RunPython(forwards, backwards),
+        migrations.RemoveField(
+            model_name="diseaseandconditiondetailpage",
+            name="description",
+        ),
+        migrations.RemoveField(
+            model_name="diseaseandconditiondetailpage",
+            name="at_a_glance",
+        ),
+        migrations.RemoveField(
+            model_name="diseaseandconditiondetailpage",
+            name="current_recommendations",
+        ),
+        migrations.RemoveField(
+            model_name="diseaseandconditiondetailpage",
+            name="surveillance",
+        ),
+        migrations.RemoveField(
+            model_name="diseaseandconditiondetailpage",
+            name="vaccine_info",
+        ),
+        migrations.RemoveField(
+            model_name="diseaseandconditiondetailpage",
+            name="diagnosis_info",
+        ),
+        migrations.RemoveField(
+            model_name="diseaseandconditiondetailpage",
+            name="provider_resources",
+        ),
+    ]

--- a/apps/disease_control/models.py
+++ b/apps/disease_control/models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.db import models
 
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
@@ -7,6 +9,34 @@ from wagtail.search import index
 
 from apps.common.models import HipBasePage
 from apps.hip.models import ListSectionBlock, StreamAndNavHeadingBlock
+
+from .blocks import (
+    AtAGlanceBlock,
+    CurrentRecommendationsBlock,
+    DescriptionBlock,
+    DiagnosisInfoBlock,
+    ProviderResourcesBlock,
+    SurveillanceBlock,
+    VaccineInfoBlock,
+)
+
+
+CONTENT_SECTION_BLOCK_TYPES = (
+    "description",
+    "at_a_glance",
+    "current_recommendations",
+    "surveillance",
+    "vaccine_info",
+    "diagnosis_info",
+    "provider_resources",
+)
+
+
+def default_disease_detail_content_sections():
+    return [
+        {"type": block_type, "value": "", "id": str(uuid.uuid4())}
+        for block_type in CONTENT_SECTION_BLOCK_TYPES
+    ]
 
 
 class DiseaseControlListPage(HipBasePage):
@@ -177,18 +207,19 @@ class DiseaseAndConditionDetailPage(HipBasePage):
     parent_page_types = ["disease_control.DiseaseAndConditionListPage"]
     subpage_types = []
 
-    description = RichTextField(
+    content_sections = StreamField(
+        [
+            ("description", DescriptionBlock()),
+            ("at_a_glance", AtAGlanceBlock()),
+            ("current_recommendations", CurrentRecommendationsBlock()),
+            ("surveillance", SurveillanceBlock()),
+            ("vaccine_info", VaccineInfoBlock()),
+            ("diagnosis_info", DiagnosisInfoBlock()),
+            ("provider_resources", ProviderResourcesBlock()),
+        ],
         blank=True,
-        help_text="Enter a short description which will be shown on the page listing diseases and conditions.",
-    )
-    at_a_glance = RichTextField(blank=True)
-    current_recommendations = RichTextField(blank=True)
-    surveillance = RichTextField(blank=True)
-    vaccine_info = RichTextField(blank=True)
-    diagnosis_info = RichTextField(blank=True)
-    provider_resources = RichTextField(
-        blank=True,
-        help_text="List resources that will be useful for healthcare providers. Resources for patients and community will be pulled automatically by including any documents that are tagged with the title of this disease/condition.",
+        default=default_disease_detail_content_sections,
+        use_json_field=True,
     )
 
     is_emergent = models.BooleanField(
@@ -210,13 +241,7 @@ class DiseaseAndConditionDetailPage(HipBasePage):
     )
 
     content_panels = HipBasePage.content_panels + [
-        FieldPanel("description"),
-        FieldPanel("at_a_glance"),
-        FieldPanel("current_recommendations"),
-        FieldPanel("surveillance"),
-        FieldPanel("vaccine_info"),
-        FieldPanel("diagnosis_info"),
-        FieldPanel("provider_resources"),
+        FieldPanel("content_sections"),
         MultiFieldPanel(
             [
                 FieldPanel("is_emergent"),
@@ -228,14 +253,45 @@ class DiseaseAndConditionDetailPage(HipBasePage):
     ]
 
     search_fields = HipBasePage.search_fields + [
-        index.SearchField("description"),
-        index.SearchField("at_a_glance"),
-        index.SearchField("current_recommendations"),
-        index.SearchField("surveillance"),
-        index.SearchField("vaccine_info"),
-        index.SearchField("diagnosis_info"),
-        index.SearchField("provider_resources"),
+        index.SearchField("content_sections"),
     ]
+
+    class Media:
+        js = ["js/disease_detail_page_admin.js"]
+
+    def _get_content_section_value(self, block_type):
+        for block in self.content_sections:
+            if block.block_type == block_type:
+                return str(block.value)
+        return ""
+
+    @property
+    def description(self):
+        return self._get_content_section_value("description")
+
+    @property
+    def at_a_glance(self):
+        return self._get_content_section_value("at_a_glance")
+
+    @property
+    def current_recommendations(self):
+        return self._get_content_section_value("current_recommendations")
+
+    @property
+    def surveillance(self):
+        return self._get_content_section_value("surveillance")
+
+    @property
+    def vaccine_info(self):
+        return self._get_content_section_value("vaccine_info")
+
+    @property
+    def diagnosis_info(self):
+        return self._get_content_section_value("diagnosis_info")
+
+    @property
+    def provider_resources(self):
+        return self._get_content_section_value("provider_resources")
 
     def get_context(self, request):
         """
@@ -244,14 +300,14 @@ class DiseaseAndConditionDetailPage(HipBasePage):
         """
         context = super().get_context(request)
 
-        context["right_nav_headings"] = [
-            self.title,
-            "Health Alerts",
-            "Surveillance",
-            "Vaccine Info",
-            "Diagnosis & Management",
-            "Resources",
-        ]
+        context["right_nav_headings"] = [self.title, "Health Alerts"]
+        if self.surveillance:
+            context["right_nav_headings"].append("Surveillance")
+        if self.vaccine_info:
+            context["right_nav_headings"].append("Vaccine Info")
+        if self.diagnosis_info:
+            context["right_nav_headings"].append("Diagnosis & Management")
+        context["right_nav_headings"].append("Resources")
 
         # prepare health alerts
         HEALTH_ALERT_MAX = 5

--- a/apps/disease_control/templates/disease_control/disease_and_condition_detail_page.html
+++ b/apps/disease_control/templates/disease_control/disease_and_condition_detail_page.html
@@ -58,61 +58,51 @@
           {% endfor %}
         </table>
 
-        <div class="nav-heading-hip" id="section-{{ "Surveillance"|slugify }}"></div>
-        <h2>Surveillance</h2>
         {% if page.surveillance %}
+          <div class="nav-heading-hip" id="section-{{ "Surveillance"|slugify }}"></div>
+          <h2>Surveillance</h2>
           {{ page.surveillance|richtext }}
-        {% else %}
-          There is no surveillance information available for {{ page.title }}.
         {% endif %}
 
-        <div class="nav-heading-hip" id="section-{{ "Vaccine info"|slugify }}"></div>
-        <h2>Vaccine Information</h2>
         {% if page.vaccine_info %}
+          <div class="nav-heading-hip" id="section-{{ "Vaccine info"|slugify }}"></div>
+          <h2>Vaccine Information</h2>
           {{ page.vaccine_info|richtext }}
-        {% else %}
-          There is no vaccine information available for {{ page.title }}.
         {% endif %}
 
-        <div class="nav-heading-hip" id="section-{{ "Diagnosis & Management"|slugify }}"></div>
-        <h2>Diagnosis & Management</h2>
         {% if page.diagnosis_info %}
+          <div class="nav-heading-hip" id="section-{{ "Diagnosis & Management"|slugify }}"></div>
+          <h2>Diagnosis & Management</h2>
           {{ page.diagnosis_info|richtext }}
-        {% else %}
-          There is no diagnosis and management information available for {{ page.title }}.
         {% endif %}
 
         <div class="nav-heading-hip" id="section-{{ "Resources"|slugify }}"></div>
         <h2>Resources</h2>
-        <h3>For Healthcare Providers:</h3>
         {% if page.provider_resources %}
+          <h3>For Healthcare Providers:</h3>
           {{ page.provider_resources|richtext }}
-        {% else %}
-          There are no healthcare provider resources available for {{ page.title }}.
         {% endif %}
-        <h3>For Patients and Community Members:</h3>
-        <div>
+        {% if documents %}
+          <h3>For Patients and Community Members:</h3>
           <div>
-            {% for document in documents %}
-              <p>
-                <a href="{{ document.url }}"><strong>{{ document.title }}</strong>
-                  <span class="pdf-icon-hip pl-2 is-size-6"></span>
-                </a>
-              </p>
-            {% empty %}
-              <p>There are no patient or community resources for {{ page.title }}.<p>
-            {% endfor %}
+            <div>
+              {% for document in documents %}
+                <p>
+                  <a href="{{ document.url }}"><strong>{{ document.title }}</strong>
+                    <span class="pdf-icon-hip pl-2 is-size-6"></span>
+                  </a>
+                </p>
+              {% endfor %}
+            </div>
           </div>
-        </div>
-        <h3>Posters:</h3>
+        {% endif %}
         {% if page.posters.all %}
+          <h3>Posters:</h3>
           <div class="columns is-multiline">
             {% for poster in page.posters.all %}
               {% include "includes/poster_card.html" %}
             {% endfor %}
           </div>
-        {% else %}
-          <p>There are no posters for {{ page.title }}.</p>
         {% endif %}
       </div>
     </div>

--- a/apps/disease_control/tests/test_models.py
+++ b/apps/disease_control/tests/test_models.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import date
 
 from apps.disease_control.tests.factories import (
@@ -170,3 +171,168 @@ def test_emergent_health_topic_order_by_latest_revision_created_at(db, rf):
                 disease_3.latest_revision_created_at
                 == context["ordered_diseases"][i].latest_revision_created_at
             )
+
+
+def _make_content_sections(sections):
+    """Helper to build a content_sections list for the StreamField.
+
+    ``sections`` is a dict mapping block type names to rich text values.
+    Only included block types will appear in the StreamField.
+    """
+    return [
+        {"type": block_type, "value": value, "id": str(uuid.uuid4())}
+        for block_type, value in sections.items()
+    ]
+
+
+def test_content_section_property_returns_value(db):
+    """Property accessors return the stored rich text value from the StreamField."""
+    sections = _make_content_sections(
+        {
+            "description": "<p>Test description</p>",
+            "at_a_glance": "<p>At a glance info</p>",
+            "surveillance": "<p>Surveillance data</p>",
+            "vaccine_info": "<p>Vaccine details</p>",
+            "diagnosis_info": "<p>Diagnosis info</p>",
+            "provider_resources": "<p>Provider resources</p>",
+            "current_recommendations": "<p>Recommendations</p>",
+        }
+    )
+    page = DiseaseAndConditionDetailPageFactory(content_sections=sections)
+
+    assert "<p>Test description</p>" in page.description
+    assert "<p>At a glance info</p>" in page.at_a_glance
+    assert "<p>Surveillance data</p>" in page.surveillance
+    assert "<p>Vaccine details</p>" in page.vaccine_info
+    assert "<p>Diagnosis info</p>" in page.diagnosis_info
+    assert "<p>Provider resources</p>" in page.provider_resources
+    assert "<p>Recommendations</p>" in page.current_recommendations
+
+
+def test_content_section_property_returns_empty_when_block_missing(db):
+    """Property accessors return empty string when a block is not in the StreamField."""
+    # Only include description — all others should be empty
+    sections = _make_content_sections({"description": "<p>Only this</p>"})
+    page = DiseaseAndConditionDetailPageFactory(content_sections=sections)
+
+    assert "<p>Only this</p>" in page.description
+    assert page.at_a_glance == ""
+    assert page.surveillance == ""
+    assert page.vaccine_info == ""
+    assert page.diagnosis_info == ""
+    assert page.provider_resources == ""
+    assert page.current_recommendations == ""
+
+
+def test_content_section_property_returns_empty_when_streamfield_empty(db):
+    """Property accessors return empty string when content_sections is completely empty."""
+    page = DiseaseAndConditionDetailPageFactory(content_sections=[])
+
+    assert page.description == ""
+    assert page.at_a_glance == ""
+    assert page.surveillance == ""
+    assert page.vaccine_info == ""
+    assert page.diagnosis_info == ""
+    assert page.provider_resources == ""
+    assert page.current_recommendations == ""
+
+
+def test_right_nav_headings_all_sections_present(db, rf):
+    """Right nav includes all section headings when all content sections have content."""
+    sections = _make_content_sections(
+        {
+            "surveillance": "<p>Data</p>",
+            "vaccine_info": "<p>Vaccine</p>",
+            "diagnosis_info": "<p>Diagnosis</p>",
+        }
+    )
+    page = DiseaseAndConditionDetailPageFactory(content_sections=sections)
+
+    context = page.get_context(rf.get("/"))
+
+    assert "Surveillance" in context["right_nav_headings"]
+    assert "Vaccine Info" in context["right_nav_headings"]
+    assert "Diagnosis & Management" in context["right_nav_headings"]
+    assert "Resources" in context["right_nav_headings"]
+    assert page.title in context["right_nav_headings"]
+    assert "Health Alerts" in context["right_nav_headings"]
+
+
+def test_right_nav_headings_no_optional_sections(db, rf):
+    """Right nav omits Surveillance/Vaccine/Diagnosis headings when those blocks are missing."""
+    sections = _make_content_sections({"description": "<p>Only description</p>"})
+    page = DiseaseAndConditionDetailPageFactory(content_sections=sections)
+
+    context = page.get_context(rf.get("/"))
+
+    assert "Surveillance" not in context["right_nav_headings"]
+    assert "Vaccine Info" not in context["right_nav_headings"]
+    assert "Diagnosis & Management" not in context["right_nav_headings"]
+    # These should always be present
+    assert page.title in context["right_nav_headings"]
+    assert "Health Alerts" in context["right_nav_headings"]
+    assert "Resources" in context["right_nav_headings"]
+
+
+def test_right_nav_headings_partial_sections(db, rf):
+    """Right nav only includes headings for sections that have content."""
+    sections = _make_content_sections(
+        {
+            "surveillance": "<p>Surveillance info</p>",
+            "diagnosis_info": "<p>Diagnosis</p>",
+        }
+    )
+    page = DiseaseAndConditionDetailPageFactory(content_sections=sections)
+
+    context = page.get_context(rf.get("/"))
+
+    assert "Surveillance" in context["right_nav_headings"]
+    assert "Diagnosis & Management" in context["right_nav_headings"]
+    assert "Vaccine Info" not in context["right_nav_headings"]
+
+
+def test_content_section_block_with_empty_value_treated_as_empty(db, rf):
+    """A block present in the StreamField but with empty value is treated as no content."""
+    sections = _make_content_sections(
+        {
+            "surveillance": "",
+            "vaccine_info": "",
+            "diagnosis_info": "",
+        }
+    )
+    page = DiseaseAndConditionDetailPageFactory(content_sections=sections)
+
+    # Properties should return empty string
+    assert page.surveillance == ""
+    assert page.vaccine_info == ""
+    assert page.diagnosis_info == ""
+
+    # Right nav should not include these empty sections
+    context = page.get_context(rf.get("/"))
+    assert "Surveillance" not in context["right_nav_headings"]
+    assert "Vaccine Info" not in context["right_nav_headings"]
+    assert "Diagnosis & Management" not in context["right_nav_headings"]
+
+
+def test_default_content_sections_creates_all_blocks(db):
+    """New pages get all 7 content section blocks seeded with empty values."""
+    from apps.disease_control.models import default_disease_detail_content_sections
+
+    sections = default_disease_detail_content_sections()
+
+    assert len(sections) == 7
+    expected_types = {
+        "description",
+        "at_a_glance",
+        "current_recommendations",
+        "surveillance",
+        "vaccine_info",
+        "diagnosis_info",
+        "provider_resources",
+    }
+    actual_types = {s["type"] for s in sections}
+    assert actual_types == expected_types
+    # All values should be empty strings
+    for section in sections:
+        assert section["value"] == ""
+        assert "id" in section

--- a/apps/disease_control/tests/test_search.py
+++ b/apps/disease_control/tests/test_search.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from wagtail.models import Page
 
@@ -8,6 +10,23 @@ from .factories import (
     DiseaseControlPageFactory,
     EmergentHealthTopicListPageFactory,
 )
+
+
+def _content_sections_with(block_type, value):
+    """Build a content_sections list with a single block containing the given value."""
+    return [{"type": block_type, "value": value, "id": str(uuid.uuid4())}]
+
+
+@pytest.fixture
+def disease_detail_with_content(disease_control_instances):
+    """Factory fixture that creates a DiseaseAndConditionDetailPage with a single content block."""
+
+    def _create(block_type, value="needle"):
+        return DiseaseAndConditionDetailPageFactory(
+            content_sections=_content_sections_with(block_type, value)
+        )
+
+    return _create
 
 
 @pytest.fixture
@@ -66,54 +85,54 @@ def test_disease_and_condition_detail_page_title(disease_control_instances):
     assert results[0].specific == obj
 
 
-def test_disease_and_condition_detail_page_description(disease_control_instances):
-    obj = DiseaseAndConditionDetailPageFactory(description="needle")
+def test_disease_and_condition_detail_page_description(disease_detail_with_content):
+    obj = disease_detail_with_content("description")
     results = Page.objects.live().search("needle")
     assert len(results) == 1
     assert results[0].specific == obj
 
 
-def test_disease_and_condition_detail_page_at_a_glance(disease_control_instances):
-    obj = DiseaseAndConditionDetailPageFactory(at_a_glance="needle")
+def test_disease_and_condition_detail_page_at_a_glance(disease_detail_with_content):
+    obj = disease_detail_with_content("at_a_glance")
     results = Page.objects.live().search("needle")
     assert len(results) == 1
     assert results[0].specific == obj
 
 
 def test_disease_and_condition_detail_page_current_recommendations(
-    disease_control_instances,
+    disease_detail_with_content,
 ):
-    obj = DiseaseAndConditionDetailPageFactory(current_recommendations="needle")
+    obj = disease_detail_with_content("current_recommendations")
     results = Page.objects.live().search("needle")
     assert len(results) == 1
     assert results[0].specific == obj
 
 
-def test_disease_and_condition_detail_page_surveillance(disease_control_instances):
-    obj = DiseaseAndConditionDetailPageFactory(surveillance="needle")
+def test_disease_and_condition_detail_page_surveillance(disease_detail_with_content):
+    obj = disease_detail_with_content("surveillance")
     results = Page.objects.live().search("needle")
     assert len(results) == 1
     assert results[0].specific == obj
 
 
-def test_disease_and_condition_detail_page_vaccine_info(disease_control_instances):
-    obj = DiseaseAndConditionDetailPageFactory(vaccine_info="needle")
+def test_disease_and_condition_detail_page_vaccine_info(disease_detail_with_content):
+    obj = disease_detail_with_content("vaccine_info")
     results = Page.objects.live().search("needle")
     assert len(results) == 1
     assert results[0].specific == obj
 
 
-def test_disease_and_condition_detail_page_diagnosis_info(disease_control_instances):
-    obj = DiseaseAndConditionDetailPageFactory(diagnosis_info="needle")
+def test_disease_and_condition_detail_page_diagnosis_info(disease_detail_with_content):
+    obj = disease_detail_with_content("diagnosis_info")
     results = Page.objects.live().search("needle")
     assert len(results) == 1
     assert results[0].specific == obj
 
 
 def test_disease_and_condition_detail_page_provider_resources(
-    disease_control_instances,
+    disease_detail_with_content,
 ):
-    obj = DiseaseAndConditionDetailPageFactory(provider_resources="needle")
+    obj = disease_detail_with_content("provider_resources")
     results = Page.objects.live().search("needle")
     assert len(results) == 1
     assert results[0].specific == obj

--- a/apps/hip/static/js/codeEmbed.js
+++ b/apps/hip/static/js/codeEmbed.js
@@ -1,0 +1,37 @@
+export default function () {
+  const mobileMediaQuery = window.matchMedia("(max-width: 768px)");
+  const embedBlocks = Array.from(document.querySelectorAll(".js-code-embed-hip"));
+
+  if (!embedBlocks.length) {
+    return;
+  }
+
+  const dismissHint = function (block) {
+    block.classList.add("code-embed-hint-dismissed-hip");
+  };
+
+  embedBlocks.forEach(function (block) {
+    const scrollArea = block.querySelector(".js-code-embed-scroll-hip");
+    if (!scrollArea) {
+      return;
+    }
+
+    const hideHintOnInteraction = function () {
+      if (!mobileMediaQuery.matches) {
+        return;
+      }
+      dismissHint(block);
+    };
+
+    scrollArea.addEventListener("touchstart", hideHintOnInteraction, { passive: true });
+    scrollArea.addEventListener("pointerdown", hideHintOnInteraction, { passive: true });
+    scrollArea.addEventListener("scroll", hideHintOnInteraction, { passive: true });
+
+    const iframe = scrollArea.querySelector("iframe");
+    if (iframe) {
+      iframe.addEventListener("load", function () {
+        iframe.style.touchAction = "auto";
+      });
+    }
+  });
+}

--- a/apps/hip/templates/hip/code_embed.html
+++ b/apps/hip/templates/hip/code_embed.html
@@ -1,8 +1,15 @@
 {% if self.heading %}
 <h2 class="is-flex is-justify-content-center">{{ self.heading }}</h2>
 {% endif %}
-<div class="is-flex is-justify-content-center">
-    {{ self.code }}
+<div class="code-embed-hip js-code-embed-hip">
+    <div class="code-embed-scroll-hip is-flex is-justify-content-center js-code-embed-scroll-hip">
+        <div class="code-embed-content-hip">
+            {{ self.code }}
+        </div>
+        <div class="code-embed-pinch-hint-hip js-code-embed-hint-hip" aria-hidden="true">
+            Pinch to zoom. Swipe to scroll.
+        </div>
+    </div>
 </div>
 {% if self.description %}
 <div class="has-text-centered mt-4">

--- a/apps/hip/templates/hip/code_embed.html
+++ b/apps/hip/templates/hip/code_embed.html
@@ -3,7 +3,7 @@
 {% endif %}
 <div class="code-embed-hip js-code-embed-hip">
     <div class="code-embed-scroll-hip is-flex is-justify-content-center js-code-embed-scroll-hip">
-        <div class="code-embed-content-hip">
+        <div class="code-embed-content-hip is-flex is-justify-content-center is-align-items-center">
             {{ self.code }}
         </div>
         <div class="code-embed-pinch-hint-hip js-code-embed-hint-hip" aria-hidden="true">

--- a/apps/hip/templates/tags/contact_info.html
+++ b/apps/hip/templates/tags/contact_info.html
@@ -19,7 +19,7 @@
     <div class="columns is-vcentered is-mobile pt-2 contact-container-hip">
       <div class="column is-3 is-mobile dark-blue-bg-hip has-text-centered mr-1 is-full-height-hip">
         <span class="is-block moon-icon-hip is-size-3 pt-5 pb-2"></span>
-        <h2 class="is-size-6">After Hours</h2>
+        <h2 class="is-size-6 after-hours-heading-hip">After Hours</h2>
       </div>
       <div class="column is-9 columns is-mobile light-grey-bg-hip ml-1 is-full-height-hip">
         <span class="column is-1 pt-4 is-block phone-icon-hip"></span>

--- a/apps/hip/tests/test_blocks.py
+++ b/apps/hip/tests/test_blocks.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ValidationError
 
 import pytest
+from bs4 import BeautifulSoup
 from wagtail.rich_text import RichText
 
 from apps.hip.blocks import ExternalContentEmbedBlock
@@ -8,6 +9,19 @@ from apps.hip.blocks import ExternalContentEmbedBlock
 
 @pytest.mark.django_db
 class TestExternalContentEmbedBlock:
+    def render_block(self, value_overrides=None):
+        block = ExternalContentEmbedBlock()
+        block_value = {
+            "heading": "My Analytics",
+            "code": '<iframe src="https://public.tableau.com/embed/123" width="800" title="Tableau Dashboard"></iframe>',
+            "description": "<p>Some insight here.</p>",
+        }
+        if value_overrides:
+            block_value.update(value_overrides)
+
+        value = block.to_python(block_value)
+        return block.render(value)
+
     def test_embed_block_required_fields(self):
         """
         Test that the 'code' field is required, but optional fields aren't.
@@ -47,24 +61,101 @@ class TestExternalContentEmbedBlock:
 
     def test_embed_block_html_rendering(self):
         """
-        Verify that the block renders the raw HTML code inside the flex container.
+        Verify that the block renders raw HTML code with responsive wrapper markup.
         """
-        block = ExternalContentEmbedBlock()
-        sample_code = (
-            '<iframe src="https://public.tableau.com/embed/123" width="800"></iframe>'
-        )
-        value = block.to_python(
-            {
-                "heading": "My Analytics",
-                "code": sample_code,
-                "description": "Some insight here.",
-            }
-        )
-        rendered_html = block.render(value)
+        rendered_html = self.render_block()
+        soup = BeautifulSoup(rendered_html, "html.parser")
 
-        assert "is-flex is-justify-content-center" in rendered_html
-        assert sample_code in rendered_html
-        assert "My Analytics" in rendered_html
+        wrapper = soup.select_one(".code-embed-hip.js-code-embed-hip")
+        assert wrapper is not None
+
+        scroll_area = wrapper.select_one(
+            ".code-embed-scroll-hip.is-flex.is-justify-content-center.js-code-embed-scroll-hip"
+        )
+        assert scroll_area is not None
+
+        content = scroll_area.select_one(".code-embed-content-hip")
+        assert content is not None
+
+        iframe = content.find("iframe")
+        assert iframe is not None
+        assert iframe["src"] == "https://public.tableau.com/embed/123"
+        assert iframe["width"] == "800"
+        assert iframe["title"] == "Tableau Dashboard"
+
+        hint = scroll_area.select_one(
+            ".code-embed-pinch-hint-hip.js-code-embed-hint-hip"
+        )
+        assert hint is not None
+        assert hint["aria-hidden"] == "true"
+        assert hint.get_text(" ", strip=True) == "Pinch to zoom. Swipe to scroll."
+
+        heading = soup.find("h2")
+        assert heading is not None
+        assert heading.get_text(strip=True) == "My Analytics"
+
+        description = soup.select_one(".has-text-centered.mt-4")
+        assert description is not None
+        assert description.get_text(" ", strip=True) == "Some insight here."
+
+    def test_embed_block_preserves_complex_tableau_embed_markup(self):
+        """
+        Verify that multi-tag embed code is preserved inside the content wrapper.
+        """
+        embed_markup = """\
+<div class="tableauPlaceholder" id="viz1680000000000"></div>
+<script type="text/javascript">var foo = "bar";</script>
+<iframe src="https://public.tableau.com/views/dashboard" width="1200"></iframe>
+"""
+
+        rendered_html = self.render_block({"code": embed_markup})
+        soup = BeautifulSoup(rendered_html, "html.parser")
+        content = soup.select_one(".code-embed-content-hip")
+
+        assert content is not None
+        assert content.select_one(".tableauPlaceholder#viz1680000000000") is not None
+
+        script_tag = content.find("script")
+        assert script_tag is not None
+        assert script_tag["type"] == "text/javascript"
+        assert 'var foo = "bar";' in script_tag.string
+
+        iframe = content.find("iframe")
+        assert iframe is not None
+        assert iframe["src"] == "https://public.tableau.com/views/dashboard"
+        assert iframe["width"] == "1200"
+
+    def test_embed_block_omits_heading_markup_when_heading_is_blank(self):
+        """
+        Verify that no heading element is rendered when heading is omitted.
+        """
+        rendered_html = self.render_block({"heading": ""})
+        soup = BeautifulSoup(rendered_html, "html.parser")
+
+        assert soup.find("h2") is None
+        assert soup.select_one(".code-embed-hip") is not None
+
+    def test_embed_block_omits_description_container_when_description_is_blank(self):
+        """
+        Verify that no description container is rendered when description is omitted.
+        """
+        rendered_html = self.render_block({"description": ""})
+        soup = BeautifulSoup(rendered_html, "html.parser")
+
+        assert soup.select_one(".has-text-centered.mt-4") is None
+        assert soup.select_one(".code-embed-pinch-hint-hip") is not None
+
+    def test_embed_block_renders_single_mobile_hint_per_embed(self):
+        """
+        Verify that each embed block renders a single mobile hint element.
+        """
+        rendered_html = self.render_block()
+        soup = BeautifulSoup(rendered_html, "html.parser")
+
+        hints = soup.select(".code-embed-pinch-hint-hip.js-code-embed-hint-hip")
+
+        assert len(hints) == 1
+        assert hints[0].get_text(" ", strip=True) == "Pinch to zoom. Swipe to scroll."
 
     def test_embed_block_unicode_support(self):
         """

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -224,3 +224,13 @@ helm uninstall arc-runner-set -n github-runner
 cd deploy/
 ansible-playbook deploy-runner.yml
 ```
+
+3. Ensure that everything is running in the `github-runner` namespace
+
+```sh
+> kubectl -n github-runner get pod                      
+NAME                                     READY   STATUS    RESTARTS   AGE
+arc-gha-rs-controller-5fd5c6b567-vwgqb   1/1     Running   0          64s
+arc-runner-set-f577755c-listener         1/1     Running   0          32s
+arc-runner-set-wnpss-runner-vq9ns        1/1     Running   0          28s
+```

--- a/hip/static/font_awesome/scss/_larger.scss
+++ b/hip/static/font_awesome/scss/_larger.scss
@@ -3,8 +3,8 @@
 
 // makes the font 33% larger relative to the icon container
 .#{$fa-css-prefix}-lg {
-  font-size: (4em / 3);
-  line-height: (3em / 4);
+  font-size: 1.3333333333em;
+  line-height: 0.75em;
   vertical-align: -.0667em;
 }
 

--- a/hip/static/font_awesome/scss/_list.scss
+++ b/hip/static/font_awesome/scss/_list.scss
@@ -3,7 +3,7 @@
 
 .#{$fa-css-prefix}-ul {
   list-style-type: none;
-  margin-left: $fa-li-width * 5/4;
+  margin-left: $fa-li-width * 1.25;
   padding-left: 0;
 
   > li { position: relative; }

--- a/hip/static/font_awesome/scss/_variables.scss
+++ b/hip/static/font_awesome/scss/_variables.scss
@@ -9,7 +9,7 @@ $fa-version:           "5.15.2" !default;
 $fa-border-color:      #eee !default;
 $fa-inverse:           #fff !default;
 $fa-li-width:          2em !default;
-$fa-fw-width:          (20em / 16);
+$fa-fw-width:          1.25em;
 $fa-primary-opacity:   1 !default;
 $fa-secondary-opacity: .4 !default;
 

--- a/hip/static/js/bundles/main.js
+++ b/hip/static/js/bundles/main.js
@@ -10741,6 +10741,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _apps_health_alerts_static_js_healthAlertMessage__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(11);
 /* harmony import */ var _apps_notifications_static_js_notificationSignup__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(12);
 /* harmony import */ var _apps_auth_content_static_js_contactInformationEdit__WEBPACK_IMPORTED_MODULE_10__ = __webpack_require__(13);
+/* harmony import */ var _apps_hip_static_js_codeEmbed__WEBPACK_IMPORTED_MODULE_11__ = __webpack_require__(14);
 
 /**
  * Javascript files must be imported here.
@@ -10770,6 +10771,7 @@ __webpack_require__.r(__webpack_exports__);
 
 
 
+
 document.addEventListener("DOMContentLoaded", function () {
   (0,_common__WEBPACK_IMPORTED_MODULE_1__["default"])();
   (0,_apps_hip_static_js_header__WEBPACK_IMPORTED_MODULE_2__["default"])();
@@ -10781,6 +10783,7 @@ document.addEventListener("DOMContentLoaded", function () {
   (0,_apps_health_alerts_static_js_healthAlertMessage__WEBPACK_IMPORTED_MODULE_8__["default"])();
   (0,_apps_notifications_static_js_notificationSignup__WEBPACK_IMPORTED_MODULE_9__["default"])();
   (0,_apps_auth_content_static_js_contactInformationEdit__WEBPACK_IMPORTED_MODULE_10__["default"])();
+  (0,_apps_hip_static_js_codeEmbed__WEBPACK_IMPORTED_MODULE_11__["default"])();
 });
 
 /***/ }),
@@ -11638,6 +11641,53 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
       window.location.href = this.dataset.href;
     });
   }
+}
+
+/***/ }),
+/* 14 */
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (/* export default binding */ __WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony default export */ function __WEBPACK_DEFAULT_EXPORT__() {
+  var mobileMediaQuery = window.matchMedia("(max-width: 768px)");
+  var embedBlocks = Array.from(document.querySelectorAll(".js-code-embed-hip"));
+  if (!embedBlocks.length) {
+    return;
+  }
+  var dismissHint = function dismissHint(block) {
+    block.classList.add("code-embed-hint-dismissed-hip");
+  };
+  embedBlocks.forEach(function (block) {
+    var scrollArea = block.querySelector(".js-code-embed-scroll-hip");
+    if (!scrollArea) {
+      return;
+    }
+    var hideHintOnInteraction = function hideHintOnInteraction() {
+      if (!mobileMediaQuery.matches) {
+        return;
+      }
+      dismissHint(block);
+    };
+    scrollArea.addEventListener("touchstart", hideHintOnInteraction, {
+      passive: true
+    });
+    scrollArea.addEventListener("pointerdown", hideHintOnInteraction, {
+      passive: true
+    });
+    scrollArea.addEventListener("scroll", hideHintOnInteraction, {
+      passive: true
+    });
+    var iframe = scrollArea.querySelector("iframe");
+    if (iframe) {
+      iframe.addEventListener("load", function () {
+        iframe.style.touchAction = "auto";
+      });
+    }
+  });
 }
 
 /***/ })

--- a/hip/static/js/disease_detail_page_admin.js
+++ b/hip/static/js/disease_detail_page_admin.js
@@ -1,0 +1,37 @@
+document.addEventListener('DOMContentLoaded', function () {
+    // Warn before deleting a StreamField block that contains content.
+    document.addEventListener('click', function (e) {
+        var deleteBtn = e.target.closest('[id$="-delete"]');
+        if (!deleteBtn) return;
+
+        // Walk up to the stream-field block container
+        var block = deleteBtn.closest('[data-contentpath]');
+        if (!block) return;
+
+        // Collect text from all contenteditable, textarea, and input elements
+        var parts = [];
+        block.querySelectorAll('[contenteditable="true"], textarea, input[type="text"]').forEach(function (el) {
+            var text = (el.innerText || el.value || '').trim();
+            if (text) parts.push(text);
+        });
+
+        if (parts.length === 0) return; // nothing to warn about
+
+        // Build a short preview (first 120 chars)
+        var preview = parts.join(' ').substring(0, 120);
+        if (parts.join(' ').length > 120) preview += '…';
+
+        // Find the block label
+        var label = '';
+        var header = block.querySelector('.w-panel__heading, .c-sf-block__header__title, h3');
+        if (header) label = header.textContent.trim();
+
+        var message = 'This' + (label ? ' "' + label + '"' : '') +
+            ' section contains content:\n\n"' + preview + '"\n\nAre you sure you want to remove it?';
+
+        if (!confirm(message)) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+        }
+    }, true); // capture phase so we fire before Wagtail's handler
+});

--- a/hip/static/js/index.js
+++ b/hip/static/js/index.js
@@ -28,6 +28,7 @@ import HealthAlertFilter from "../../../apps/health_alerts/static/js/healthAlert
 import HealthAlertMessage from "../../../apps/health_alerts/static/js/healthAlertMessage";
 import NotificationSignup from "../../../apps/notifications/static/js/notificationSignup";
 import ContactInformationEditModal from "../../../apps/auth_content/static/js/contactInformationEdit";
+import CodeEmbed from "../../../apps/hip/static/js/codeEmbed";
 
 document.addEventListener("DOMContentLoaded", function() {
   Common();
@@ -40,4 +41,5 @@ document.addEventListener("DOMContentLoaded", function() {
   HealthAlertMessage();
   NotificationSignup();
   ContactInformationEditModal();
+  CodeEmbed();
 });

--- a/hip/static/styles/common.scss
+++ b/hip/static/styles/common.scss
@@ -208,6 +208,7 @@ body.modal-is-open-hip {
     overflow-x: auto;
     overflow-y: hidden;
     -webkit-overflow-scrolling: touch;
+    justify-content: flex-start !important;
   }
 
   .code-embed-content-hip {

--- a/hip/static/styles/common.scss
+++ b/hip/static/styles/common.scss
@@ -179,3 +179,61 @@ body.modal-is-open-hip {
     width: 1px;
   }
 }
+
+.code-embed-hip {
+  width: 100%;
+}
+
+.code-embed-scroll-hip {
+  position: relative;
+  width: 100%;
+}
+
+.code-embed-content-hip {
+  width: 100%;
+
+  iframe {
+    display: block;
+    margin: 0 auto;
+    max-width: none;
+  }
+}
+
+.code-embed-pinch-hint-hip {
+  display: none;
+}
+
+@media screen and (max-width: $breakpoint-mobile) {
+  .code-embed-scroll-hip {
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .code-embed-content-hip {
+    min-width: max-content;
+  }
+
+  .code-embed-pinch-hint-hip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    padding: 0.4rem 0.6rem;
+    border-radius: 4px;
+    color: $white;
+    background-color: rgba(0, 0, 0, 0.7);
+    font-size: $is-size-7;
+    line-height: 1.2;
+    pointer-events: none;
+    opacity: 1;
+    transition: opacity 0.35s ease;
+  }
+
+  .code-embed-hip.code-embed-hint-dismissed-hip .code-embed-pinch-hint-hip {
+    opacity: 0;
+    visibility: hidden;
+  }
+}

--- a/hip/static/styles/tags/contact_info.scss
+++ b/hip/static/styles/tags/contact_info.scss
@@ -4,6 +4,11 @@
   .contact-container-hip {
     height: 150px;
   }
+
+  .after-hours-heading-hip {
+    color: white;
+  }
+
   .biz-info-hip {
     height: 62.5px;
   }

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -1,6 +1,6 @@
 # base.in
 
-django==5.2.8
+django==5.2.14
 django-dotenv
 django_extensions
 django_model_utils
@@ -31,7 +31,7 @@ psycopg2-binary==2.9.9
 
 
 # Wagtail
-wagtail==7.0.3
+wagtail==7.0.7
 wagtailmenus==4.0.2
 wagtail-modeladmin==2.2.0
 

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -36,7 +36,7 @@ diff-match-patch==20200713
     # via django-import-export
 dj-database-url==0.5.0
     # via -r requirements/base/base.in
-django==5.2.8
+django==5.2.14
     # via
     #   -r requirements/base/base.in
     #   django-appconf
@@ -179,7 +179,7 @@ urllib3==1.26.4
     # via
     #   botocore
     #   requests
-wagtail==7.0.3
+wagtail==7.0.7
     # via
     #   -r requirements/base/base.in
     #   wagtail-modeladmin
@@ -191,7 +191,9 @@ wagtailmenus==4.0.2
 whitenoise==5.2.0
     # via -r requirements/base/base.in
 willow[heif]==1.11.0
-    # via wagtail
+    # via
+    #   wagtail
+    #   willow
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -108,7 +108,7 @@ defusedxml==0.7.1
     #   willow
 distlib==0.3.8
     # via virtualenv
-django==5.2.8
+django==5.2.14
     # via
     #   -c requirements/base/base.txt
     #   django-debug-toolbar
@@ -586,7 +586,7 @@ urwid-readline==0.14
     # via pudb
 virtualenv==20.26.2
     # via pre-commit
-wagtail==7.0.3
+wagtail==7.0.7
     # via
     #   -c requirements/base/base.txt
     #   wagtail-factories


### PR DESCRIPTION
This PR does the following:

- Change font color in report a decease page
- Improve embed block to render better on mobile
- Address some sass deprecation warnings

**Note:** This PR also includes a minor improvement to the runner documentation.

**Technical Note:** For the Disease and condition detail page, _health alerts_, _posters_, and _documents_ are not fields defined on the model but rather FKs. All three dynamic sections (health alerts, posters, documents) follow the same pattern: data lives elsewhere and is pulled in via relationships or queries in `get_context()`. Hence why the change on `dicease_and_condition_detail_page.html` to only show those conditionally/if they have data.

Closes #330 