### PR TITLE
Kubernetes Upgrade v1.33 to v1.35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ hip/static/bundles/main.js
 # Ansible
 bin/
 deploy/roles/*
+deploy/collections/*
 .vault_pass
 *.retry
 deploy.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,8 +125,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   openssh-client -- for git over SSH
 #   sudo -- to run commands as superuser
 #   vim -- enhanced vi editor for commits
-ENV KUBE_CLIENT_VERSION="v1.33.0"
-ENV HELM_VERSION="3.18.3"
+ENV KUBE_CLIENT_VERSION="v1.35.0"
+ENV HELM_VERSION="4.2.0"
 ENV POSTGRESQL_CLIENT_VERSION="15"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     --mount=type=cache,mode=0755,target=/root/.cache/pip \

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -97,8 +97,7 @@ cloudformation_stack:
 k8s_cluster_type: aws
 # aws eks describe-cluster --name=philly-hip-stack-cluster --query 'cluster.arn'
 k8s_context: "arn:aws:eks:us-east-1:061553509755:cluster/{{ cluster_name }}"
-k8s_ingress_nginx_chart_version: "4.14.1"
-k8s_cert_manager_chart_version: "v1.18"
+k8s_cert_manager_chart_version: "v1.20.2"
 k8s_letsencrypt_email: admin@caktusgroup.com
 k8s_iam_users: [noop]  # https://github.com/caktus/ansible-role-k8s-web-cluster/issues/17
 # aws-for-fluent-bit
@@ -135,13 +134,6 @@ k8s_container_resources:
 
 k8s_migrations_enabled: true
 k8s_collectstatic_enabled: false
-k8s_container_ingress_annotations:
-  nginx.ingress.kubernetes.io/proxy-body-size: 100m
-  # These are in seconds, but need to be specified without the trailing 's'
-  # usually seen in nginx.conf proper.
-  nginx.ingress.kubernetes.io/proxy-connect-timeout: 1800
-  nginx.ingress.kubernetes.io/proxy-send-timeout: 1800
-  nginx.ingress.kubernetes.io/proxy-read-timeout: 1800
 # Shared environment variables:
 env_database_url: "postgres://{{ app_name }}_{{ env_name }}:{{ database_password }}@{{ DatabaseAddress }}:5432/{{ app_name }}_{{ env_name }}"
 env_django_settings: "{{ app_name }}.settings.deploy"
@@ -225,7 +217,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.33.0
+k8s_descheduler_chart_version: v0.34.0
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:
@@ -241,7 +233,6 @@ k8s_hosting_services_image_tag: 0.6.0-postgres15
 
 # Traefik Service
 k8s_traefik_replica_count: 2
-k8s_traefik_ingress_is_default: true
 
 # Traefik dashboard
 k8s_enable_traefik_dashboard: false

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -217,7 +217,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.34.0
+k8s_descheduler_chart_version: v0.35.1
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -4,11 +4,11 @@ roles:
     name: caktus.aws-web-stacks
     version: v0.3.0
   - src: https://github.com/caktus/ansible-role-k8s-web-cluster
-    version: v1.11.0
+    version: v1.12.1
     name: caktus.k8s-web-cluster
   - src: https://github.com/caktus/ansible-role-django-k8s
     name: caktus.django-k8s
-    version: v1.12.1
+    version: v1.12.2
   - src: https://github.com/caktus/ansible-role-k8s-hosting-services
     name: caktus.k8s-hosting-services
     version: v0.13.0

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -18,9 +18,9 @@ django-sass-processor
 django-phonenumber-field
 django-honeypot
 whitenoise
-boto3==1.39.2
-botocore==1.39.2
-urllib3>=2.7.0
+boto3==1.43.11
+botocore==1.43.11
+urllib3<2.4.0
 python-dateutil>=2.9.0
 six>=1.17.0
 libsass==0.23.0

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -12,9 +12,9 @@ asgiref==3.11.1
     #   social-auth-app-django
 beautifulsoup4==4.14.3
     # via wagtail
-boto3==1.39.2
+boto3==1.43.11
     # via -r requirements/base/base.in
-botocore==1.39.2
+botocore==1.43.11
     # via
     #   -r requirements/base/base.in
     #   boto3
@@ -171,7 +171,7 @@ requests-oauthlib==2.0.0
     # via social-auth-core
 rjsmin==1.2.5
     # via django-compressor
-s3transfer==0.13.1
+s3transfer==0.17.1
     # via boto3
 six==1.17.0
     # via
@@ -194,7 +194,7 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   django-stubs-ext
     #   django-tasks
-urllib3==2.7.0
+urllib3==2.3.0
     # via
     #   -r requirements/base/base.in
     #   botocore

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -15,12 +15,12 @@ ansible==13.7.0
 invoke-kubesae==0.1.0
 
 # AWS tools
-awscli==1.41.2
+awscli==1.45.11
 awslogs
 Jinja2==3.1.6
 openshift==0.13.2
-kubernetes==32.0.1
-kubernetes-validate~=1.34.1
+kubernetes==35.0.0
+kubernetes-validate~=1.35.0
 
 pre-commit
 coverage

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -20,7 +20,7 @@ awslogs
 Jinja2==3.1.6
 openshift==0.13.2
 kubernetes==32.0.1
-kubernetes-validate~=1.33.0
+kubernetes-validate~=1.34.1
 
 pre-commit
 coverage

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -304,7 +304,7 @@ kubernetes==32.0.1
     # via
     #   -r requirements/dev/dev.in
     #   openshift
-kubernetes-validate==1.33.1
+kubernetes-validate==1.34.1
     # via -r requirements/dev/dev.in
 laces==0.1.2
     # via

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -40,7 +40,7 @@ attrs==26.1.0
     # via
     #   jsonschema
     #   referencing
-awscli==1.41.2
+awscli==1.45.11
     # via -r requirements/dev/dev.in
 awslogs==0.15.0
     # via -r requirements/dev/dev.in
@@ -55,12 +55,12 @@ black==26.5.1
     # via -r requirements/dev/dev.in
 bleach[css]==6.3.0
     # via nbconvert
-boto3==1.39.2
+boto3==1.43.11
     # via
     #   -c requirements/base/base.txt
     #   awslogs
     #   invoke-kubesae
-botocore==1.39.2
+botocore==1.43.11
     # via
     #   -c requirements/base/base.txt
     #   awscli
@@ -100,7 +100,6 @@ cryptography==48.0.0
     # via
     #   -c requirements/base/base.txt
     #   ansible-core
-    #   google-auth
 debugpy==1.8.20
     # via ipykernel
 decorator==5.3.1
@@ -197,8 +196,6 @@ flake8==7.3.0
     # via -r requirements/dev/dev.in
 fqdn==1.5.1
     # via jsonschema
-google-auth==2.53.0
-    # via kubernetes
 h11==0.16.0
     # via httpcore
 httpcore==1.0.9
@@ -300,11 +297,11 @@ jupyterlab-pygments==0.3.0
     # via nbconvert
 jupyterlab-server==2.28.0
     # via jupyterlab
-kubernetes==32.0.1
+kubernetes==35.0.0
     # via
     #   -r requirements/dev/dev.in
     #   openshift
-kubernetes-validate==1.34.1
+kubernetes-validate==1.35.0
     # via -r requirements/dev/dev.in
 laces==0.1.2
     # via
@@ -348,7 +345,6 @@ notebook-shim==0.2.4
 oauthlib==3.3.1
     # via
     #   -c requirements/base/base.txt
-    #   kubernetes
     #   requests-oauthlib
 openpyxl==3.1.5
     # via
@@ -416,11 +412,7 @@ pudb==2025.1.5
 pure-eval==0.2.3
     # via stack-data
 pyasn1==0.6.3
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.2
-    # via google-auth
+    # via rsa
 pycodestyle==2.14.0
     # via flake8
 pycparser==3.0
@@ -518,7 +510,7 @@ rpds-py==0.30.0
     #   referencing
 rsa==4.7.2
     # via awscli
-s3transfer==0.13.1
+s3transfer==0.17.1
     # via
     #   -c requirements/base/base.txt
     #   awscli
@@ -588,7 +580,7 @@ tzdata==2026.2
     # via arrow
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.7.0
+urllib3==2.3.0
     # via
     #   -c requirements/base/base.txt
     #   botocore


### PR DESCRIPTION
This PR updates requirements to work with K8s version 1.35.x.

**Traefik**
```
> helm -n traefik list                       

NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
traefik traefik         3               2026-06-16 13:29:00.850094 -0400 EDT    deployed        traefik-40.2.0  v3.7.1     
```

**Cert Manager**
```
> helm -n cert-manager list                      
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    13              2026-06-16 13:22:40.781414 -0400 EDT    deployed        cert-manager-v1.20.2    v1.20.2
```

**Descheduler**
```
> helm -n kube-system list                      
NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION     
descheduler                     kube-system     11              2026-06-17 09:19:58.087464 -0400 EDT    deployed        descheduler-0.35.1                 0.35.1 
```

**Docker upgrade tests performed:**

I took down my docker image and rebuilt without cache. 

Then:
```
# Ensure docker image still builds successfully
> docker build -t hip:latest .

# Verify new K8s version
> docker run --rm hip:latest kubectl version --client            
Client Version: v1.35.0
Kustomize Version: v5.7.1


# Verify new Helm version
>docker run --rm hip:latest helm version --short         
v4.2.0+g0646808
```

<img width="1830" height="1007" alt="Screenshot 2026-06-17 at 9 52 25 AM" src="https://github.com/user-attachments/assets/34a3bb95-6397-4897-964d-f9ccd4174dd7" />


_I ran into this issue while doing this upgrade._ 

```
TASK [caktus.k8s-web-cluster : Remove ingress-nginx] *********************************************
[ERROR]: Task failed: Module failed: HTTPSConnectionPool(host='c3219f3cb49e4b1c82cfe8c82a846345.sk1.us-east-1.eks.amazonaws.com', port=443): Max retries exceeded with url: /version (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1035)'))): [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1035)

Task failed: Module failed: HTTPSConnectionPool(host='c3219f3cb49e4b1c82cfe8c82a846345.sk1.us-east-1.eks.amazonaws.com', port=443): Max retries exceeded with url: /version (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1035)')))
Origin: /Users/ronardlunagerman/Desktop/caktus_development/philly-hip/deploy/roles/caktus.k8s-web-cluster/tasks/main.yml:16:3

14   when: k8s_purge_cert_manager
15
16 - name: Remove ingress-nginx
     ^ column 3

<<< caused by >>>

[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1035)

fatal: [production]: FAILED! => 
    changed: false
    msg: 'Task failed: Module failed: HTTPSConnectionPool(host=''c3219f3cb49e4b1c82cfe8c82a846345.sk1.us-east-1.eks.amazonaws.com'',
        port=443): Max retries exceeded with url: /version (Caused by SSLError(SSLCertVerificationError(1,
        ''[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority
        Key Identifier (_ssl.c:1035)''))): [SSL: CERTIFICATE_VERIFY_FAILED] certificate
        verify failed: Missing Authority Key Identifier (_ssl.c:1035)'
```

I found discussions online, other people have been running into similar issues
Python: https://github.com/kubernetes-client/python/issues/2394
https://github.com/awslabs/mcp/issues/3791

The temporary patch is to install a version of `urllib3<2.4.0`.
